### PR TITLE
Implement DevTool spawn stubs

### DIFF
--- a/src/Dev/DevTool.cs
+++ b/src/Dev/DevTool.cs
@@ -1,0 +1,36 @@
+using Microsoft.Xna.Framework;
+
+namespace HackenSlay;
+
+public static class DevTool
+{
+    public static Weapon SpawnWeapon(string weaponName)
+    {
+        switch (weaponName.ToLower())
+        {
+            case "dummy":
+                return new DummyWeapon();
+            default:
+                Debug.Log($"Not implemented yet: {weaponName}", DebugLevel.LOW, DebugCategory.WEAPON);
+                return null;
+        }
+    }
+
+    public static Item SpawnItem(string itemName)
+    {
+        switch (itemName.ToLower())
+        {
+            case "dummy":
+                return new DummyItem();
+            default:
+                Debug.Log($"Not implemented yet: {itemName}", DebugLevel.LOW, DebugCategory.ITEM);
+                return null;
+        }
+    }
+
+    public static Enemy SpawnEnemy(string enemyName)
+    {
+        Debug.Log($"Not implemented yet: {enemyName}", DebugLevel.LOW, DebugCategory.ENEMY);
+        return new Enemy(enemyName);
+    }
+}

--- a/src/Items/DummyItem.cs
+++ b/src/Items/DummyItem.cs
@@ -1,0 +1,24 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace HackenSlay;
+
+public class DummyItem : Item
+{
+    public DummyItem() : base(null)
+    {
+        _name = "DummyItem";
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+    }
+
+    public override void Draw(SpriteBatch spriteBatch, Player player)
+    {
+    }
+
+    public override void Handle(GameHS game)
+    {
+    }
+}

--- a/src/Items/Weapons/DummyWeapon.cs
+++ b/src/Items/Weapons/DummyWeapon.cs
@@ -1,0 +1,9 @@
+namespace HackenSlay;
+
+public class DummyWeapon : Weapon
+{
+    public DummyWeapon() : base(1, 1f, 1f)
+    {
+        _name = "DummyWeapon";
+    }
+}

--- a/src/Tests/Debug.cs
+++ b/src/Tests/Debug.cs
@@ -16,7 +16,9 @@ public static class Debug
         { DebugCategory.DRAWING, false},
         { DebugCategory.PLAYERCALC, false},
         { DebugCategory.USERINPUT, true},
-        { DebugCategory.WEAPON, true}
+        { DebugCategory.WEAPON, true},
+        { DebugCategory.ITEM, true},
+        { DebugCategory.ENEMY, true}
     };
 
     public static void Log(string msg, DebugLevel debugLevel, DebugCategory debugCategory)
@@ -77,5 +79,5 @@ public enum DebugLevel
 
 public enum DebugCategory
 {
-    VISUAL, ANIMATIONHANDLER, DRAWING, PLAYERCALC, USERINPUT, WEAPON, ITEM
+    VISUAL, ANIMATIONHANDLER, DRAWING, PLAYERCALC, USERINPUT, WEAPON, ITEM, ENEMY
 }

--- a/src/World/Enemy.cs
+++ b/src/World/Enemy.cs
@@ -1,0 +1,11 @@
+namespace HackenSlay;
+
+public class Enemy : TextureObject
+{
+    public Enemy(string name)
+    {
+        _name = name;
+        _isActive = true;
+        _isVisible = true;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DevTool` with `SpawnWeapon`, `SpawnItem`, `SpawnEnemy`
- add placeholder classes `Enemy`, `DummyWeapon`, and `DummyItem`
- extend debug categories to include ITEM and ENEMY

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bf10a8e748329a8a35c62a304c0a2