### PR TITLE
Fix timer update bug in ranged weapon

### DIFF
--- a/src/Items/Collectibles/Collectible.cs
+++ b/src/Items/Collectibles/Collectible.cs
@@ -4,7 +4,7 @@ namespace HackenSlay;
 
 public class Collectible : TextureObject
 {
-    public Collectible(Player player, GameHS game) : base(game)
+    public Collectible(Player player, GameHS game) : base()
     {
 
     }

--- a/src/Items/Item.cs
+++ b/src/Items/Item.cs
@@ -7,7 +7,7 @@ namespace HackenSlay
     {
         
 
-        protected Item(GameHS game) : base(game)
+        protected Item() : base()
         {
         }
 

--- a/src/Items/Weapons/RangedWeapon.cs
+++ b/src/Items/Weapons/RangedWeapon.cs
@@ -40,6 +40,9 @@ public class RangedWeapon : Weapon
             }
         }
 
+        // track the elapsed time since the last bullet was fired
+        TimeSinceLastBullet += gameTime.ElapsedGameTime.Milliseconds;
+
         // Input checks, e.g. for shooting and reloading
 
         // if reloading, then add gameTime to elapsedTimeReload. If ElapsedTimeReload >= TimeForReload, then set IsReloading to false, RemainingBullets = MagazineSize, RemainingMagazines--, ElapsedTimeReload = 0


### PR DESCRIPTION
## Summary
- fix wrong constructors in Item and Collectible classes
- ensure RangedWeapon accumulates elapsed time before checking fire rate

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbf6fb02083298567ffd590fbf89e