### PR TITLE
Add dev menu action with reload

### DIFF
--- a/data/input/keyboard.json
+++ b/data/input/keyboard.json
@@ -37,6 +37,9 @@
     ],
     "pause": [
       "Escape"
+    ],
+    "dev_menu": [
+      "F7"
     ]
   }
   

--- a/src/Core/Input/InputMapping.cs
+++ b/src/Core/Input/InputMapping.cs
@@ -49,6 +49,9 @@ namespace HackenSlay
 
         public void Initialize()
         {
+            KeyboardMapping.Clear();
+            GamePadMapping.Clear();
+
             LoadFromJson("data/input/keyboard.json");
             LoadFromJson("data/input/gamepad.json");
         }

--- a/src/Core/Input/UserInput.cs
+++ b/src/Core/Input/UserInput.cs
@@ -24,6 +24,11 @@ namespace HackenSlay
             _inputMapping.Initialize();
         }
 
+        public void ReloadMappings()
+        {
+            _inputMapping.Initialize();
+        }
+
         public bool IsActionPressed(string action)
         {
             KeyboardState keyboardState = Keyboard.GetState();

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -63,6 +63,9 @@ public class GameHS : Game
 
     protected override void Update(GameTime gameTime)
     {
+        if (userInput.IsActionPressed("dev_menu"))
+            userInput.ReloadMappings();
+
         if (userInput.IsActionPressed("pause"))
             Exit();
 


### PR DESCRIPTION
## Summary
- map new `dev_menu` action to F7 in default keyboard layout
- clear existing mappings before re-loading in `InputMapping.Initialize`
- expose `UserInput.ReloadMappings` and trigger on F7 in `GameHS.Update`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf10955608329a327e762eff67416