### PR TITLE
Add procedural map generator

### DIFF
--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using HackenSlay.World.Map;
 
 namespace HackenSlay;
 
@@ -17,6 +18,7 @@ public class GameHS : Game
     public UserInput userInput { get; }
     public SpriteFont _font;
     public Player player { get; private set; }
+    private MapGenerator _mapGenerator;
 
     public GameHS()
     {
@@ -52,6 +54,8 @@ public class GameHS : Game
     protected override void LoadContent()
     {
         _spriteBatch = new SpriteBatch(GraphicsDevice);
+        // create map after graphics device is ready
+        _mapGenerator = new MapGenerator(GraphicsDevice, 50, 50, 64);
         // TODO: use this.Content to load your game content here
         foreach (TextureObject obj in _textureObjects)
         {
@@ -81,6 +85,7 @@ public class GameHS : Game
 
         // TODO: Add your drawing code here
         _spriteBatch.Begin();
+        _mapGenerator?.Draw(_spriteBatch);
 
         foreach (TextureObject obj in _textureObjects)
         {

--- a/src/World/Map/MapGenerator.cs
+++ b/src/World/Map/MapGenerator.cs
@@ -1,0 +1,124 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace HackenSlay.World.Map;
+
+public class MapGenerator
+{
+    public TileType[,] Tiles { get; private set; }
+    public int Width { get; }
+    public int Height { get; }
+    public int TileSize { get; }
+
+    private readonly Random _random;
+    private readonly Texture2D _pixel;
+
+    public MapGenerator(GraphicsDevice graphicsDevice, int width, int height, int tileSize = 64, int? seed = null)
+    {
+        Width = width;
+        Height = height;
+        TileSize = tileSize;
+        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _pixel = new Texture2D(graphicsDevice, 1, 1);
+        _pixel.SetData(new[] { Color.White });
+        Tiles = new TileType[Width, Height];
+        Generate();
+    }
+
+    private void Generate()
+    {
+        // Start with all tiles empty
+        for (int x = 0; x < Width; x++)
+            for (int y = 0; y < Height; y++)
+                Tiles[x, y] = TileType.Empty;
+
+        GenerateStreets();
+        PlaceObstacles();
+        PlaceEnemySpawns();
+    }
+
+    private void GenerateStreets()
+    {
+        int x = Width / 2;
+        int y = Height / 2;
+        int steps = Width * Height;
+        Tiles[x, y] = TileType.Street;
+
+        for (int i = 0; i < steps; i++)
+        {
+            int dir = _random.Next(4);
+            switch (dir)
+            {
+                case 0: x++; break;
+                case 1: x--; break;
+                case 2: y++; break;
+                case 3: y--; break;
+            }
+            x = Math.Clamp(x, 0, Width - 1);
+            y = Math.Clamp(y, 0, Height - 1);
+            Tiles[x, y] = TileType.Street;
+        }
+    }
+
+    private void PlaceObstacles()
+    {
+        double obstacleChance = _random.Next(10, 21) / 100.0; // between 10% and 20%
+        for (int x = 0; x < Width; x++)
+        {
+            for (int y = 0; y < Height; y++)
+            {
+                if (Tiles[x, y] == TileType.Empty && _random.NextDouble() < obstacleChance)
+                {
+                    Tiles[x, y] = TileType.Obstacle;
+                }
+            }
+        }
+    }
+
+    private void PlaceEnemySpawns()
+    {
+        int spawnsLeft = Math.Max(1, (Width + Height) / 20);
+        int attempts = 0;
+        while (spawnsLeft > 0 && attempts < 1000)
+        {
+            int x = _random.Next(Width);
+            int y = _random.Next(Height);
+            bool onEdge = x == 0 || x == Width - 1 || y == 0 || y == Height - 1;
+            if (onEdge && Tiles[x, y] == TileType.Empty)
+            {
+                Tiles[x, y] = TileType.EnemySpawn;
+                spawnsLeft--;
+            }
+            attempts++;
+        }
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        for (int x = 0; x < Width; x++)
+        {
+            for (int y = 0; y < Height; y++)
+            {
+                Color color = Color.Transparent;
+                switch (Tiles[x, y])
+                {
+                    case TileType.Street:
+                        color = Color.Gray;
+                        break;
+                    case TileType.Obstacle:
+                        color = Color.DarkGray;
+                        break;
+                    case TileType.EnemySpawn:
+                        color = Color.Red;
+                        break;
+                }
+                if (color != Color.Transparent)
+                {
+                    Rectangle rect = new Rectangle(x * TileSize, y * TileSize, TileSize, TileSize);
+                    spriteBatch.Draw(_pixel, rect, color);
+                }
+            }
+        }
+    }
+}

--- a/src/World/Map/TileType.cs
+++ b/src/World/Map/TileType.cs
@@ -1,0 +1,9 @@
+namespace HackenSlay.World.Map;
+
+public enum TileType
+{
+    Empty,
+    Street,
+    Obstacle,
+    EnemySpawn
+}


### PR DESCRIPTION
## Summary
- implement `MapGenerator` with random-walk streets, obstacles, enemy spawns
- provide `TileType` enum for map tiles
- instantiate and draw the map in `GameHS`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c09152ef08329970963b6e8db7791