### PR TITLE
Add setup script with .NET 8 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# HackenSlay
+
+A simple Hack n Slay game written in C# using MonoGame.
+
+## Setup and Compilation
+
+The project provides a helper script to install dependencies and build the game assets.
+
+1. Make sure the script is executable:
+   ```bash
+   chmod +x scripts/setup.sh
+   ```
+2. Run the setup script:
+   ```bash
+   ./scripts/setup.sh
+   ```
+   Add `--build` to also compile the project immediately:
+   ```bash
+   ./scripts/setup.sh --build
+   ```
+3. To build manually afterwards, run:
+   ```bash
+   dotnet build
+   ```
+
+The script installs the .NET 8 SDK via `apt`, installs the SDL and OpenAL packages required by MonoGame, restores dotnet tools and builds the content pipeline.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+# Install .NET 8 SDK
+sudo apt-get update
+sudo apt-get install -y wget apt-transport-https
+wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+sudo apt-get update
+sudo apt-get install -y dotnet-sdk-8.0
+
+# Install SDL and OpenAL
+sudo apt-get install -y libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libopenal-dev
+
+# Restore dotnet tools and build content
+dotnet tool restore
+dotnet mgcb /@:Content/Content.mgcb
+
+# Optionally build the project when --build is passed
+if [ "$1" == "--build" ]; then
+    dotnet build
+fi


### PR DESCRIPTION
## Summary
- add a setup script for installing .NET 8, SDL and OpenAL
- document setup and build steps in a new README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c03d81e448329a2ee32441fb4a858