### PR TITLE
Add Wiki docs and fix README merge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # HackenSlay
 
-<<<< codex/create-knowledge-base-folder-and-documentation
-A simple "hack n slay" game written in C#. Source code lives in the `src` folder and additional information can be found in the `wiki` directory.
+A Hack n Slay game built with [MonoGame](https://www.monogame.net/). Source code lives in the `src` folder and additional information can be found in the `wiki` directory.
 
 Conversation transcripts and other helpful knowledge are stored under `docs/knowledge-base`. Codex will scan this folder when searching the repository's documentation.
-
-====
-<< codex/update-readme-with-game-details
-A Hack n Slay game built with [MonoGame](https://www.monogame.net/).
 
 ## Prerequisites
 
@@ -29,8 +24,6 @@ dotnet run
 ## Documentation
 
 Further information and developer guides can be found in the [wiki/](wiki/) directory.
-======
-A simple Hack n Slay game written in C# using MonoGame.
 
 ## Setup and Compilation
 
@@ -54,5 +47,3 @@ The project provides a helper script to install dependencies and build the game 
    ```
 
 The script installs the .NET 8 SDK via `apt`, installs the SDL and OpenAL packages required by MonoGame, restores dotnet tools and builds the content pipeline.
->>>> main
->>>> main

--- a/Wiki/Core/README.md
+++ b/Wiki/Core/README.md
@@ -1,0 +1,2 @@
+# Core
+Kurzbeschreibung des Moduls.

--- a/Wiki/Dev/README.md
+++ b/Wiki/Dev/README.md
@@ -1,0 +1,2 @@
+# Dev
+Kurzbeschreibung des Moduls.

--- a/Wiki/Handlers/README.md
+++ b/Wiki/Handlers/README.md
@@ -1,0 +1,2 @@
+# Handlers
+Kurzbeschreibung des Moduls.

--- a/Wiki/Items/README.md
+++ b/Wiki/Items/README.md
@@ -1,0 +1,2 @@
+# Items
+Kurzbeschreibung des Moduls.

--- a/Wiki/Networking/README.md
+++ b/Wiki/Networking/README.md
@@ -1,0 +1,2 @@
+# Networking
+Kurzbeschreibung des Moduls.

--- a/Wiki/README.md
+++ b/Wiki/README.md
@@ -1,0 +1,3 @@
+# Wiki
+
+Dieses Verzeichnis enthält Dokumentation zu den Spielmodulen und zur Sprintplanung.

--- a/Wiki/Sprints/Sprint-01/README.md
+++ b/Wiki/Sprints/Sprint-01/README.md
@@ -1,0 +1,3 @@
+# Sprint 01
+
+In diesem Sprint wird die Spielfigur implementiert und die grundlegende Karten-Generierung erstellt. Außerdem sollen erste Sammelobjekte eingebunden werden.

--- a/Wiki/Sprints/Sprint-02/README.md
+++ b/Wiki/Sprints/Sprint-02/README.md
@@ -1,0 +1,3 @@
+# Sprint 02
+
+Dieser Sprint fokussiert sich auf Gegner-KI und das Kampfsystem. Weiterhin sollen Menüs für Inventar und Einstellungen entwickelt werden.

--- a/Wiki/UI/README.md
+++ b/Wiki/UI/README.md
@@ -1,0 +1,2 @@
+# UI
+Kurzbeschreibung des Moduls.

--- a/Wiki/World/README.md
+++ b/Wiki/World/README.md
@@ -1,0 +1,2 @@
+# World
+Kurzbeschreibung des Moduls.


### PR DESCRIPTION
## Summary
- create `Wiki/` directory with subfolders for modules and sprint planning
- add placeholder docs for each module
- add Sprint-01 and Sprint-02 planning docs
- fix merge conflicts in `README.md`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c39c2db8883298ece535a2d0e2ea2