### PR TITLE
Add ChatGPT wiki guideline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dotnet-install.sh

--- a/wiki/About.md
+++ b/wiki/About.md
@@ -6,3 +6,6 @@ The code is located in /src
 The wiki and all other information is located in /wiki
 The Wiki folder structure is categorizing the different parts of the game.
 
+Available folders include:
+- **weltgenerierung** – Notizen zur Weltgestaltung
+- **leitfaden** – Richtlinien und Anleitungen, z.B. der ChatGPT-Kodex

--- a/wiki/leitfaden/chatgpt-kodex.md
+++ b/wiki/leitfaden/chatgpt-kodex.md
@@ -1,0 +1,23 @@
+# Leitfaden: ChatGPT-Kodex zur effizienten Wiki-Erstellung
+
+Dieser Eintrag beschreibt eine Struktur, wie neue Wiki-Beiträge mithilfe von ChatGPT entstehen können, ohne dass einleitende Sätze ständig wiederholt werden müssen. So lassen sich Ideen direkt in neuen Text umsetzen.
+
+## Zweck
+
+- **Wiederholungen vermeiden**: Formuliere Einleitungen nicht jedes Mal neu. Nutze stattdessen eine feste Vorlage.
+- **Klare Struktur**: Halte Abschnitte wie Einleitung, Hauptteil und Fazit kurz und prägnant.
+- **Flexible Themen**: ChatGPT kann frei formulierte Ideen in einen neuen Wiki-Eintrag überführen.
+
+## Vorgehensweise
+
+1. **Neuen Titel festlegen**: Überlege dir einen aussagekräftigen Namen für den Wiki-Eintrag.
+2. **Kurze Einleitung**: Fasse in ein bis zwei Sätzen zusammen, worum es geht. Wiederhole diese Struktur bei allen Einträgen.
+3. **Gedanken ordnen**: Liste Stichpunkte auf oder erstelle Abschnitte, damit ChatGPT daraus einen kohärenten Text erzeugen kann.
+4. **Automatisierte Erstellung**: Wenn möglich, verweise in deiner Anfrage an ChatGPT auf diesen Leitfaden. So entfällt das wiederholte Erklären, wie Einträge aufgebaut sein sollen.
+
+## Gestaltungsidee
+
+- Lege dir eine Vorlage an, die du für jedes neue Thema nutzen kannst. Diese Vorlage enthält die obigen Abschnitte.
+- Du kannst die Vorlage als Markdown-Datei speichern und bei Bedarf erweitern.
+- So kannst du spontan neue Ideen diktieren und ChatGPT übernimmt die Ausformulierung anhand der Vorlage.
+


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude dotnet-install script
- document wiki folder structure in `wiki/About.md`
- add `wiki/leitfaden/chatgpt-kodex.md` with instructions for creating new wiki entries

## Testing
- `dotnet build` *(fails: DevTool class errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ff610288329ad7d981b25d0f4e9