### PR TITLE
Add generative content wiki entry

### DIFF
--- a/wiki/About.md
+++ b/wiki/About.md
@@ -9,3 +9,4 @@ The Wiki folder structure is categorizing the different parts of the game.
 Available folders include:
 - **weltgenerierung** – Notizen zur Weltgestaltung
 - **leitfaden** – Richtlinien und Anleitungen, z.B. der ChatGPT-Kodex
+- **inhalt** – Beschreibungen zu Gegnern, Gebäuden und weiteren Spielelementen

--- a/wiki/inhalt/README.md
+++ b/wiki/inhalt/README.md
@@ -1,0 +1,2 @@
+# Inhalt
+Kurze Sammlung von Artikeln zu Spielmechaniken und -objekten.

--- a/wiki/inhalt/generative-inhalte.md
+++ b/wiki/inhalt/generative-inhalte.md
@@ -1,0 +1,17 @@
+# Generative Inhalte
+
+Die Spielwelt soll langfristig abwechslungsreich bleiben. Gegner, Gebäude und andere Elemente können automatisch erzeugt werden, statt alles manuell vorzubereiten.
+
+## Prozedurale Gegner
+- Verschiedene Grundtypen werden kombiniert, um immer neue Varianten zu schaffen.
+- Attribute wie Stärke, Aussehen oder Verhalten entstehen durch Zufallsparameter.
+
+## Automatisch erzeugte Gebäude
+- Größe, Form und Einrichtung werden dynamisch bestimmt.
+- So entstehen Städte, die bei jedem Spieldurchlauf einzigartig wirken.
+
+## Sprites durch KI unterstützen
+- Ein neuronales Netz könnte einfache Grafiken basierend auf Textbeschreibungen generieren.
+- Damit lassen sich neue Gegner oder Objekte einbinden, ohne jedes einzelne Sprite selbst zu zeichnen.
+
+Neue Inhalte können so fortlaufend entstehen und halten das Spiel lebendig.


### PR DESCRIPTION
## Summary
- add new `wiki/inhalt` folder for game content notes
- document how generative algorithms could create enemies, buildings and sprites
- update wiki index

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686c460d975883299943932c72c39054