### PR TITLE
Add sprint backlog

### DIFF
--- a/Wiki/Sprints/Backlog.md
+++ b/Wiki/Sprints/Backlog.md
@@ -1,0 +1,9 @@
+# Projekt-Backlog
+
+Die folgenden Features sind geplant und in der aktuellen Priorität sortiert:
+
+1. **Kartenverbesserungen**: detailliertere Tilesets und prozedurale Varianten für abwechslungsreiche Levels.
+2. **UI-Menüs**: Inventar- und Einstellungsmenüs sowie ein Pausenmenü.
+3. **Netzwerkunterstützung**: grundlegender Multiplayer mit Lobby und Synchronisation.
+4. **Gegner- und NPC-System**: verbesserte KI, Wegfindung und Händler.
+5. **Audio-Optimierung**: Sounds und Hintergrundmusik einbinden.

--- a/Wiki/Sprints/README.md
+++ b/Wiki/Sprints/README.md
@@ -1,0 +1,7 @@
+# Sprint Übersicht
+
+Dieses Verzeichnis enthält die Planung der einzelnen Entwicklungsphasen.
+
+- [Backlog](Backlog.md)
+- [Sprint 01](Sprint-01/README.md)
+- [Sprint 02](Sprint-02/README.md)


### PR DESCRIPTION
## Summary
- document planned features in `Wiki/Sprints/Backlog.md`
- link backlog from a new overview file `Wiki/Sprints/README.md`

## Testing
- `dotnet build` *(fails: DevTool duplicate definition)*

------
https://chatgpt.com/codex/tasks/task_e_686c588854ec8329bebe5ac49b8f3116