### PR TITLE
Add menu system wiki entry

### DIFF
--- a/wiki/About.md
+++ b/wiki/About.md
@@ -9,3 +9,4 @@ The Wiki folder structure is categorizing the different parts of the game.
 Available folders include:
 - **weltgenerierung** – Notizen zur Weltgestaltung
 - **leitfaden** – Richtlinien und Anleitungen, z.B. der ChatGPT-Kodex
+- **spielstatus** – Informationen zu Startscreen und Pausemenue

--- a/wiki/spielstatus/menu-system.md
+++ b/wiki/spielstatus/menu-system.md
@@ -1,0 +1,17 @@
+# Spielstatus und Menüs
+
+In HackenSlay gibt es verschiedene Status, die das laufende Spiel unterbrechen oder starten können. Ein Startscreen wird angezeigt, bevor das eigentliche Spiel läuft. Dort lassen sich ein neues Spiel beginnen, ein Spielstand laden oder die Einstellungen öffnen. Im Spiel selbst kann ein Pausemenü geöffnet werden, das die Spielwelt anhält und weitere Optionen bietet.
+
+## Startscreen
+- Erscheint vor Spielbeginn
+- Optionen: **Neues Spiel**, **Spielstand laden**, **Einstellungen**
+
+## Pausemenü
+- Pausiert das Spielgeschehen
+- Zugriff auf Einstellungen während des Spiels
+- Erlaubt Speichern, Beenden oder Fortsetzen
+
+## Einstellungen
+- Audio-, Grafik- und Steuerungsoptionen
+- Änderungen sind sowohl im Startscreen als auch im Pausemenü erreichbar
+- Fortschritt kann gespeichert und später geladen werden


### PR DESCRIPTION
## Summary
- document start screen and pause menu
- link new wiki folder in root wiki overview

## Testing
- `dotnet build --no-restore` *(fails: MonoGame.Framework.DesktopGL was not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c46714850832993717707123640db