### PR TITLE
Add developer console

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ dotnet test
 dotnet run
 ```
 
+Press `~` to open the developer console while running. Use F7 to toggle the
+debug overlay.
+
 ## Documentation
 
 Further information and developer guides can be found in the [Wiki/](Wiki/) directory.

--- a/Wiki/Dev/README.md
+++ b/Wiki/Dev/README.md
@@ -19,8 +19,16 @@ This folder describes tools used during development.
 ## Developer Overlay
 
 The overlay in `src/UI/Menus/DevOverlay.cs` can be toggled with the `dev_menu` input and draws a small
-window for debugging. It can be combined with `DevTool` or `DevSpawner` to spawn weapons, items or
-enemies while the game is running.
+window for debugging.
+
+`src/UI/Menus/DevConsole.cs` implements a simple console that opens with the `dev_console`
+action (bound to the `~` key by default). Commands allow spawning objects and modifying
+stats at runtime. Example commands:
+
+```text
+spawn enemy dummy
+set player health 200
+```
 
 ## Example
 

--- a/data/input/keyboard.json
+++ b/data/input/keyboard.json
@@ -40,6 +40,9 @@
     ],
     "dev_menu": [
       "F7"
+    ],
+    "dev_console": [
+      "OemTilde"
     ]
   }
   

--- a/docs/knowledge-base/2025-07-10-dev-console.md
+++ b/docs/knowledge-base/2025-07-10-dev-console.md
@@ -1,0 +1,11 @@
+# Dev Console Discussion
+
+A request introduced a developer console similar to those in Valve games.
+It should open with the `~` key and allow spawning enemies or modifying
+player stats while running.
+
+Implemented a `DevConsole` overlay at `src/UI/Menus/DevConsole.cs`.
+It listens for `dev_console` input and processes simple commands:
+`spawn enemy <name>`, `spawn weapon <name>`, `spawn item <name>`, and
+`set player <attr> <value>` or `set enemy <attr> <value>`.
+The console draws its history and current input on screen.

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -24,3 +24,4 @@ Below is a list of available conversation files:
 - [2025-07-08-gameplay-loop.md](2025-07-08-gameplay-loop.md)
 - [2025-07-09-implemented-features.md](2025-07-09-implemented-features.md)
 - [2025-07-09-dynamic-paths.md](2025-07-09-dynamic-paths.md)
+- [2025-07-10-dev-console.md](2025-07-10-dev-console.md)

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -16,6 +16,8 @@ public class GameHS : Game
     private SpriteBatch _spriteBatch;
 
     List<TextureObject> _textureObjects;
+    private DevConsole _devConsole;
+    public IEnumerable<TextureObject> Objects => _textureObjects;
     public UserInput userInput { get; }
     public SpriteFont _font;
     public Player player { get; private set; }
@@ -42,6 +44,7 @@ public class GameHS : Game
         _textureObjects = new List<TextureObject>();
         userInput = new UserInput(this);
         _devTool = new DevOverlay();
+        _devConsole = new DevConsole();
         _startMenu = new HackenSlay.UI.Menus.StartMenu();
         _pauseMenu = new HackenSlay.UI.Menus.PauseMenu();
     }
@@ -70,6 +73,7 @@ public class GameHS : Game
         }
 
         _devTool.LoadContent(this);
+        _devConsole.LoadContent(this);
 
         _font = Content.Load<SpriteFont>("fonts/Arial");
     }
@@ -92,6 +96,7 @@ public class GameHS : Game
         }
 
         _devTool.Update(this, gameTime);
+        _devConsole.Update(this, gameTime);
 
         base.Update(gameTime);
     }
@@ -116,11 +121,18 @@ public class GameHS : Game
         _pauseMenu.Draw(this, _spriteBatch);
 
         _devTool.Draw(this, _spriteBatch);
+        _devConsole.Draw(this, _spriteBatch);
 
         Debug.DrawScreenSize(this, _spriteBatch, _font);
 
         _spriteBatch.End();
 
         base.Draw(gameTime);
+    }
+
+    public void AddObject(TextureObject obj)
+    {
+        _textureObjects.Add(obj);
+        obj.LoadContent(this);
     }
 }

--- a/src/UI/Menus/DevConsole.cs
+++ b/src/UI/Menus/DevConsole.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+
+namespace HackenSlay;
+
+public class DevConsole
+{
+    bool _isVisible;
+    bool _togglePrev;
+    Texture2D? _pixel;
+    Rectangle _rect;
+    string _input = string.Empty;
+    readonly List<string> _history = new();
+    GameHS? _game;
+
+    public void LoadContent(GameHS game)
+    {
+        _game = game;
+        _pixel = new Texture2D(game.GraphicsDevice, 1, 1);
+        _pixel.SetData(new[] { Color.White });
+        int width = game.Window.ClientBounds.Width - 20;
+        int height = game.Window.ClientBounds.Height / 4;
+        _rect = new Rectangle(10, game.Window.ClientBounds.Height - height - 10, width, height);
+        game.Window.TextInput += OnTextInput;
+    }
+
+    private void OnTextInput(object? sender, TextInputEventArgs e)
+    {
+        if (!_isVisible) return;
+        if (e.Key == Keys.Back)
+        {
+            if (_input.Length > 0)
+                _input = _input[..^1];
+        }
+        else if (e.Key == Keys.Enter)
+        {
+            ExecuteCommand(_input);
+            _input = string.Empty;
+        }
+        else if (!char.IsControl(e.Character))
+        {
+            _input += e.Character;
+        }
+    }
+
+    public void Update(GameHS game, GameTime gameTime)
+    {
+        bool pressed = game.userInput.IsActionPressed("dev_console");
+        if (pressed && !_togglePrev)
+            _isVisible = !_isVisible;
+        _togglePrev = pressed;
+    }
+
+    public void Draw(GameHS game, SpriteBatch spriteBatch)
+    {
+        if (!_isVisible || _pixel == null) return;
+        spriteBatch.Draw(_pixel, _rect, Color.Black * 0.8f);
+        Vector2 pos = new Vector2(_rect.X + 10, _rect.Y + 10);
+        int start = Math.Max(0, _history.Count - 5);
+        for (int i = start; i < _history.Count; i++)
+        {
+            spriteBatch.DrawString(game._font, _history[i], pos, Color.White);
+            pos.Y += 20;
+        }
+        spriteBatch.DrawString(game._font, "> " + _input, new Vector2(_rect.X + 10, _rect.Bottom - 30), Color.Yellow);
+    }
+
+    private void ExecuteCommand(string command)
+    {
+        if (_game == null || string.IsNullOrWhiteSpace(command)) return;
+        _history.Add(command);
+        var parts = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return;
+
+        switch (parts[0].ToLower())
+        {
+            case "spawn":
+                if (parts.Length >= 3)
+                {
+                    string type = parts[1].ToLower();
+                    string name = parts[2];
+                    switch (type)
+                    {
+                        case "enemy":
+                            var enemy = DevSpawner.SpawnEnemy(name);
+                            if (enemy != null)
+                            {
+                                enemy._pos = _game.player._pos + new Vector2(50, 0);
+                                _game.AddObject(enemy);
+                                _history.Add($"Spawned enemy {name}");
+                            }
+                            break;
+                        case "weapon":
+                            var weapon = DevSpawner.SpawnWeapon(name);
+                            if (weapon != null)
+                            {
+                                _game.AddObject(weapon);
+                                _history.Add($"Spawned weapon {name}");
+                            }
+                            break;
+                        case "item":
+                            var item = DevSpawner.SpawnItem(name);
+                            if (item != null)
+                            {
+                                _game.AddObject(item);
+                                _history.Add($"Spawned item {name}");
+                            }
+                            break;
+                    }
+                }
+                break;
+            case "set":
+                if (parts.Length >= 4 && parts[1].ToLower() == "player")
+                {
+                    string attr = parts[2].ToLower();
+                    string value = parts[3];
+                    switch (attr)
+                    {
+                        case "health":
+                            if (int.TryParse(value, out int h)) _game.player._health = h;
+                            break;
+                        case "walkspeed":
+                            if (float.TryParse(value, out float ws)) _game.player._walkspeed = ws;
+                            break;
+                        case "runspeed":
+                            if (float.TryParse(value, out float rs)) _game.player._runspeed = rs;
+                            break;
+                        case "strength":
+                            if (int.TryParse(value, out int st)) _game.player._strength = st;
+                            break;
+                    }
+                    _history.Add($"Set player {attr} to {value}");
+                }
+                else if (parts.Length >= 4 && parts[1].ToLower() == "enemy")
+                {
+                    string attr = parts[2].ToLower();
+                    string value = parts[3];
+                    foreach (var obj in _game.Objects)
+                    {
+                        if (obj is Enemy enemy)
+                        {
+                            switch (attr)
+                            {
+                                case "health":
+                                    if (int.TryParse(value, out int eh)) enemy._health = eh;
+                                    break;
+                                case "strength":
+                                    if (int.TryParse(value, out int es)) enemy._strength = es;
+                                    break;
+                            }
+                        }
+                    }
+                    _history.Add($"Set all enemies {attr} to {value}");
+                }
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a runtime dev console overlay to spawn entities and change stats
- hook console into game loop and map to the `~` key
- document usage and update input mappings
- record the design discussion in the knowledge base

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686fc9b96e688329a09febc8f18e6b71