### PR TITLE
Add tile map engine with camera

### DIFF
--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -22,6 +22,8 @@ public class GameHS : Game
     public SpriteFont _font;
     public Player player { get; private set; }
     private MapGenerator _mapGenerator;
+    private TileMap _tileMap;
+    private Camera2D _camera;
     private DevOverlay _devTool;
     private HackenSlay.UI.Menus.StartMenu _startMenu;
     private HackenSlay.UI.Menus.PauseMenu _pauseMenu;
@@ -47,6 +49,7 @@ public class GameHS : Game
         _devConsole = new DevConsole();
         _startMenu = new HackenSlay.UI.Menus.StartMenu();
         _pauseMenu = new HackenSlay.UI.Menus.PauseMenu();
+        _camera = new Camera2D();
     }
 
     protected override void Initialize()
@@ -66,6 +69,7 @@ public class GameHS : Game
         _spriteBatch = new SpriteBatch(GraphicsDevice);
         // create map after graphics device is ready
         _mapGenerator = new MapGenerator(GraphicsDevice, 50, 50, 64);
+        _tileMap = WorldBuilder.Build(GraphicsDevice, _mapGenerator);
         // TODO: use this.Content to load your game content here
         foreach (TextureObject obj in _textureObjects)
         {
@@ -95,6 +99,8 @@ public class GameHS : Game
             obj.Update(this, gameTime);
         }
 
+        _camera.CenterOn(player._pos, GraphicsDevice.Viewport);
+
         _devTool.Update(this, gameTime);
         _devConsole.Update(this, gameTime);
 
@@ -106,8 +112,8 @@ public class GameHS : Game
         GraphicsDevice.Clear(Color.CornflowerBlue);
 
         // TODO: Add your drawing code here
-        _spriteBatch.Begin();
-        _mapGenerator?.Draw(_spriteBatch);
+        _spriteBatch.Begin(transformMatrix: _camera.GetViewMatrix());
+        _tileMap?.Draw(_spriteBatch);
 
         if (!_startMenu.IsActive)
         {

--- a/src/World/Map/Camera2D.cs
+++ b/src/World/Map/Camera2D.cs
@@ -1,0 +1,16 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace HackenSlay.World.Map;
+
+public class Camera2D
+{
+    public Vector2 Position { get; private set; }
+
+    public Matrix GetViewMatrix() => Matrix.CreateTranslation(new Vector3(-Position, 0));
+
+    public void CenterOn(Vector2 target, Viewport viewport)
+    {
+        Position = target - new Vector2(viewport.Width / 2f, viewport.Height / 2f);
+    }
+}

--- a/src/World/Map/TileAtlas.cs
+++ b/src/World/Map/TileAtlas.cs
@@ -1,0 +1,36 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace HackenSlay.World.Map;
+
+public static class TileAtlas
+{
+    public static Texture2D Create(GraphicsDevice device, int tileSize)
+    {
+        const int cols = 3; // width of atlas in tiles
+        const int rows = 2;
+        var texture = new Texture2D(device, cols * tileSize, rows * tileSize);
+        var data = new Color[cols * rows * tileSize * tileSize];
+
+        void Fill(int c, int r, Color color)
+        {
+            for (int x = 0; x < tileSize; x++)
+            {
+                for (int y = 0; y < tileSize; y++)
+                {
+                    int index = ((r * tileSize + y) * cols * tileSize) + (c * tileSize + x);
+                    data[index] = color;
+                }
+            }
+        }
+
+        Fill(0,0, Color.Black);      // Empty
+        Fill(1,0, Color.Gray);       // Street
+        Fill(2,0, Color.DarkGray);   // Obstacle
+        Fill(0,1, Color.Red);        // Enemy spawn
+        Fill(1,1, Color.Green);      // Structure spawn
+
+        texture.SetData(data);
+        return texture;
+    }
+}

--- a/src/World/Map/TileMap.cs
+++ b/src/World/Map/TileMap.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace HackenSlay.World.Map;
+
+public class TileMap
+{
+    private readonly TileType[,] _tiles;
+    private readonly Texture2D _atlas;
+    private readonly Dictionary<TileType, Rectangle> _sources;
+    public int TileSize { get; }
+
+    public TileMap(TileType[,] tiles, Texture2D atlas, int tileSize)
+    {
+        _tiles = tiles;
+        _atlas = atlas;
+        TileSize = tileSize;
+        _sources = new Dictionary<TileType, Rectangle>
+        {
+            { TileType.Empty, new Rectangle(0,0,tileSize,tileSize) },
+            { TileType.Street, new Rectangle(tileSize,0,tileSize,tileSize) },
+            { TileType.Obstacle, new Rectangle(2*tileSize,0,tileSize,tileSize) },
+            { TileType.EnemySpawn, new Rectangle(0,tileSize,tileSize,tileSize) },
+            { TileType.StructureSpawn, new Rectangle(tileSize,tileSize,tileSize,tileSize) }
+        };
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        int width = _tiles.GetLength(0);
+        int height = _tiles.GetLength(1);
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                TileType t = _tiles[x, y];
+                Rectangle dest = new Rectangle(x * TileSize, y * TileSize, TileSize, TileSize);
+                spriteBatch.Draw(_atlas, dest, _sources[t], Color.White);
+            }
+        }
+    }
+}

--- a/src/World/Map/WorldBuilder.cs
+++ b/src/World/Map/WorldBuilder.cs
@@ -1,0 +1,12 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace HackenSlay.World.Map;
+
+public static class WorldBuilder
+{
+    public static TileMap Build(GraphicsDevice device, MapGenerator generator)
+    {
+        var atlas = TileAtlas.Create(device, generator.TileSize);
+        return new TileMap(generator.Tiles, atlas, generator.TileSize);
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple Camera2D
- implement TileAtlas and TileMap for drawing map tiles
- add WorldBuilder helper
- use camera and tile map in `GameHS`

## Testing
- `dotnet build --no-restore`
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877b41d247083299db9f6f5c390a5ef