### PR TITLE
Cleanup setup script

### DIFF
--- a/scripts/fetch-devops-backlog.ps1
+++ b/scripts/fetch-devops-backlog.ps1
@@ -1,3 +1,4 @@
+# Erstellt mit Unterstützung von OpenAI Codex
 # === Konfiguration ===
 $organization = "FWI95"
 $project = "games"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,60 +1,42 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Erstellt mit Unterstützung von OpenAI Codex
 set -e
 
+# Install core dependencies
 echo "Installing system dependencies..."
 sudo apt-get update
-sudo apt-get install -y wget unzip libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+sudo apt-get install -y wget unzip apt-transport-https \
+    libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+    libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libopenal-dev
 
-echo "Installing .NET SDK..."
-wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
-chmod +x dotnet-install.sh
-./dotnet-install.sh --channel 8.0
-export DOTNET_ROOT=$HOME/.dotnet
-export PATH=$PATH:$HOME/.dotnet
-
-echo "Installing Node.js and npm..."
+# Install Node.js
+echo "Installing Node.js..."
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
-echo "Installing MonoGame templates..."
-dotnet new --install MonoGame.Templates.CSharp
-
-echo "Setup completed!"
-
-
-echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
-echo 'export PATH=$PATH:$HOME/.dotnet' >> ~/.bashrc
-
-
-echo "Done"
-
-
-# Todo: this is the newer script, has to be consolidated with the old one above
-
-#!/usr/bin/env bash
-set -e
-
-
-# Install .NET 8 SDK
-echo "Installing system dependencies..."
-sudo apt-get update
-sudo apt-get install -y wget unzip libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev apt-transport-https
+# Install .NET SDK
+echo "Installing .NET SDK..."
 wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
 sudo apt-get update
 sudo apt-get install -y dotnet-sdk-8.0
 
-# Install SDL and OpenAL
-sudo apt-get install -y libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libopenal-dev
+# Install MonoGame templates
+echo "Installing MonoGame templates..."
+dotnet new --install MonoGame.Templates.CSharp
 
-# Restore dotnet tools and build content
+# Restore tools and build content
+echo "Restoring tools and building content..."
 dotnet tool restore
 dotnet mgcb /@:Content/Content.mgcb
 
-# Optionally build the project when --build is passed
+# Optionally build the project
 if [ "$1" == "--build" ]; then
     dotnet build
 fi
 
-pwsh -File ./scripts/fetch-devops-backlog.ps1 # Fetch the backlog from Azure DevOps
+# Fetch the backlog from Azure DevOps
+pwsh -File ./scripts/fetch-devops-backlog.ps1
+
+echo "Setup completed!"


### PR DESCRIPTION
## Summary
- consolidate scripts/setup.sh and add Codex notice
- add Codex notice to fetch-devops-backlog.ps1
- keep setup.sh executable

## Testing
- `dotnet test` *(fails: The name '_textureObjects' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68780769ba7c8329a0972548ee53ddfc