### PR TITLE
Implement basic AudioManager integration

### DIFF
--- a/docs/knowledge-base/2025-07-11-audio-manager.md
+++ b/docs/knowledge-base/2025-07-11-audio-manager.md
@@ -1,0 +1,16 @@
+# Basic Audio Manager
+
+A conversation required adding a rudimentary audio system similar to the existing
+`AnimationHandler`. Each `TextureObject` now owns an `AudioManager` used to play
+sound effects or music. The new system loads songs for menus and effects for
+player actions and enemy death.
+
+Key changes:
+- `AudioManager` now supports loading and playing `SoundEffect` and `Song`.
+- `TextureObject` instantiates an `AudioManager` by default.
+- `Player` plays an attack sound when using a weapon.
+- `Enemy` plays a death sound when its health reaches zero.
+- `StartMenu` and `PauseMenu` load background music that plays while active.
+
+Paths for the audio files are placeholders like `audio/attack` or `audio/start_menu`.
+Actual assets can be added later through the MonoGame content pipeline.

--- a/src/Core/Audio/AudioManager.cs
+++ b/src/Core/Audio/AudioManager.cs
@@ -1,21 +1,42 @@
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Media;
 using System.Collections.Generic;
 
 namespace HackenSlay.Audio;
 
 public class AudioManager
 {
-    private readonly Dictionary<string, SoundEffect> _sounds = new();
-
-    public void Load(ContentManager content, string name, string path)
+    private readonly Dictionary<string, SoundEffect> _soundEffects = new();
+    private readonly Dictionary<string, Song> _songs = new();
+    public void LoadSoundEffect(ContentManager content, string name, string path)
     {
-        _sounds[name] = content.Load<SoundEffect>(path);
+        _soundEffects[name] = content.Load<SoundEffect>(path);
     }
 
-    public void Play(string name)
+    public void LoadSong(ContentManager content, string name, string path)
     {
-        if (_sounds.TryGetValue(name, out var s))
-            s.Play();
+        _songs[name] = content.Load<Song>(path);
+    }
+
+    public void PlaySoundEffect(string name)
+    {
+        if (_soundEffects.TryGetValue(name, out var effect))
+            effect.Play();
+    }
+
+    public void PlaySong(string name, bool isRepeating = true)
+    {
+        if (_songs.TryGetValue(name, out var song))
+        {
+            MediaPlayer.IsRepeating = isRepeating;
+            MediaPlayer.Play(song);
+        }
+    }
+
+    public void StopSong()
+    {
+        if (MediaPlayer.State != MediaState.Stopped)
+            MediaPlayer.Stop();
     }
 }

--- a/src/Core/Objects/TextureObject.cs
+++ b/src/Core/Objects/TextureObject.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using HackenSlay.Core.Animation;
+using HackenSlay.Audio;
 using HackenSlay.Core.Dev;
 
 namespace HackenSlay.Core.Objects;
@@ -20,6 +21,7 @@ public class TextureObject
     public Texture2D _sprite { get; set; }
     public SpriteFont _font;
     public AnimationHandler animationHandler;
+    public AudioManager AudioManager { get; }
     public Vector2 _velocity;
     public string _name { get; set; }
     public int _health { get; set; }
@@ -34,6 +36,7 @@ public class TextureObject
         _velocity = new Vector2(0, 0);
 
         animationHandler = new AnimationHandler();
+        AudioManager = new AudioManager();
     }
 
     public virtual void LoadContent(GameHS game)

--- a/src/Core/UI/Menus/PauseMenu.cs
+++ b/src/Core/UI/Menus/PauseMenu.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using HackenSlay.Audio;
 
 namespace HackenSlay.UI.Menus;
 
@@ -7,6 +8,13 @@ public class PauseMenu
 {
     private bool _isPaused;
     private bool _prevState;
+    private readonly AudioManager _audio = new();
+    private bool _musicPlayed;
+
+    public void LoadContent(GameHS game)
+    {
+        _audio.LoadSong(game.Content, "pauseMusic", "audio/pause_menu");
+    }
 
     public void Update(GameHS game)
     {
@@ -14,6 +22,16 @@ public class PauseMenu
         if (pressed && !_prevState)
         {
             _isPaused = !_isPaused;
+            if (_isPaused && !_musicPlayed)
+            {
+                _audio.PlaySong("pauseMusic");
+                _musicPlayed = true;
+            }
+            else if (!_isPaused)
+            {
+                _audio.StopSong();
+                _musicPlayed = false;
+            }
         }
         _prevState = pressed;
     }

--- a/src/Core/UI/Menus/StartMenu.cs
+++ b/src/Core/UI/Menus/StartMenu.cs
@@ -1,19 +1,35 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using HackenSlay.Audio;
 
 namespace HackenSlay.UI.Menus;
 
 public class StartMenu
 {
     private bool _active = true;
+    private readonly AudioManager _audio = new();
+    private bool _musicPlayed;
 
     public bool IsActive => _active;
 
+    public void LoadContent(GameHS game)
+    {
+        _audio.LoadSong(game.Content, "startMusic", "audio/start_menu");
+    }
+
     public void Update(GameHS game)
     {
+        if (_active && !_musicPlayed)
+        {
+            _audio.PlaySong("startMusic");
+            _musicPlayed = true;
+        }
+
         if (_active && game.userInput.IsActionPressed("pause"))
         {
             _active = false;
+            _audio.StopSong();
+            _musicPlayed = false;
         }
     }
 

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -87,6 +87,8 @@ public class GameHS : Game
 
         _devTool.LoadContent(this);
         _devConsole.LoadContent(this);
+        _startMenu.LoadContent(this);
+        _pauseMenu.LoadContent(this);
 
         _font = Content.Load<SpriteFont>("fonts/Arial");
     }

--- a/src/Objects/Enemy/Enemy.cs
+++ b/src/Objects/Enemy/Enemy.cs
@@ -16,6 +16,12 @@ public class Enemy : TextureObject
         _health = 3; // a small default value
     }
 
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        AudioManager.LoadSoundEffect(game.Content, "die", "audio/enemy_die");
+    }
+
     public override void Update(GameHS game, GameTime gameTime)
     {
         base.Update(game, gameTime);
@@ -24,6 +30,7 @@ public class Enemy : TextureObject
         {
             _isActive = false;
             _isVisible = false;
+            AudioManager.PlaySoundEffect("die");
         }
     }
 }

--- a/src/Objects/Player/Player.cs
+++ b/src/Objects/Player/Player.cs
@@ -44,6 +44,7 @@ public class Player : TextureObject
         animationHandler.LoadContent(game, _animationdata);
         itemActionHandler.LoadContent(game);
         _currentWeapon.LoadContent(game);
+        AudioManager.LoadSoundEffect(game.Content, "attack", "audio/attack");
     }
 
     public override void Draw(GameHS game, SpriteBatch spriteBatch)
@@ -72,6 +73,7 @@ public class Player : TextureObject
         if (game.userInput.IsActionPressed("primary_attack"))
         {
             _currentWeapon.Use(_pos, Vector2.Zero, this, game.userInput.GetMousePosition());
+            AudioManager.PlaySoundEffect("attack");
         }
 
         if (game.userInput.IsActionPressed("secondary_attack"))


### PR DESCRIPTION
## Summary
- extend `AudioManager` to load `SoundEffect` and `Song`
- give `TextureObject` a default `AudioManager`
- load and play sounds for start/pause menus, player attack and enemy death
- call menu `LoadContent` during game setup
- document the new audio system

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687822ae356883299b4e02004f2095da