### PR TITLE
Allow movement across larger maps

### DIFF
--- a/src/Core/Objects/TextureObject.cs
+++ b/src/Core/Objects/TextureObject.cs
@@ -49,13 +49,13 @@ public class TextureObject
 
         Vector2 newPos = _pos + _velocity;
 
-        if (newPos.X + animationHandler.GetSubImage().Width > game.Window.ClientBounds.Width
+        if (newPos.X + animationHandler.GetSubImage().Width > game.MapSize.X
             || newPos.X < 0)
         {
             _velocity.X = 0;
         }
 
-        if (newPos.Y + animationHandler.GetSubImage().Height > game.Window.ClientBounds.Height
+        if (newPos.Y + animationHandler.GetSubImage().Height > game.MapSize.Y
             || newPos.Y < 0)
         {
             _velocity.Y = 0;

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -34,6 +34,7 @@ public class GameHS : Game
     private DevOverlay _devTool;
     private HackenSlay.UI.Menus.StartMenu _startMenu;
     private HackenSlay.UI.Menus.PauseMenu _pauseMenu;
+    public Vector2 MapSize { get; private set; }
 
     public GameHS()
     {
@@ -82,6 +83,9 @@ public class GameHS : Game
         // create map after graphics device is ready
         _mapGenerator = new MapGenerator(GraphicsDevice, 50, 50, 64);
         _tileMap = WorldBuilder.Build(GraphicsDevice, _mapGenerator);
+        MapSize = new Vector2(
+            _mapGenerator.Width * _mapGenerator.TileSize,
+            _mapGenerator.Height * _mapGenerator.TileSize);
         // TODO: use this.Content to load your game content here
         _visualEngine.LoadContent(this);
 


### PR DESCRIPTION
## Summary
- track map dimensions with a new `GameHS.MapSize` property
- use map bounds instead of screen bounds in `TextureObject.Update`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6878230315c88329a8506e11d1bf2434