### PR TITLE
Fix warnings in build

### DIFF
--- a/src/Core/Input/UserInput.cs
+++ b/src/Core/Input/UserInput.cs
@@ -19,8 +19,6 @@ namespace HackenSlay
     {
         private Game _game;
         private InputMapping _inputMapping;
-        private InputDevice _inputDevice = InputDevice.Keyboard; // Default to keyboard
-
 
         public UserInput(Game game)
         {

--- a/src/Core/Networking/NetworkManager.cs
+++ b/src/Core/Networking/NetworkManager.cs
@@ -1,6 +1,8 @@
 using System.Net.Sockets;
 using System.Text;
 
+#nullable enable
+
 namespace HackenSlay.Networking;
 
 public class NetworkManager

--- a/src/Core/UI/Menus/DevConsole.cs
+++ b/src/Core/UI/Menus/DevConsole.cs
@@ -4,6 +4,8 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 
+#nullable enable
+
 namespace HackenSlay;
 
 public class DevConsole

--- a/src/Objects/Items/Weapons/Weapon.cs
+++ b/src/Objects/Items/Weapons/Weapon.cs
@@ -24,11 +24,11 @@ public class Weapon : TextureObject
         Projectiles = new List<Projectile>();
     }
 
-    public virtual void Update(GameHS game, GameTime gameTime)
+    public override void Update(GameHS game, GameTime gameTime)
     {
     }
 
-    public virtual void Draw(GameHS game, SpriteBatch spriteBatch)
+    public override void Draw(GameHS game, SpriteBatch spriteBatch)
     {
     }
 

--- a/src/Objects/World/Map/MapGenerator.cs
+++ b/src/Objects/World/Map/MapGenerator.cs
@@ -2,6 +2,8 @@ using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
+#nullable enable
+
 namespace HackenSlay.World.Map;
 
 public class MapGenerator

--- a/src/Objects/World/Transport/TransportSystem.cs
+++ b/src/Objects/World/Transport/TransportSystem.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace HackenSlay.World.Transport;
 
 public class Planet

--- a/src/Tests/HackenSlay.Tests/ItemActionHandlerTests.cs
+++ b/src/Tests/HackenSlay.Tests/ItemActionHandlerTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Xunit;
 using HackenSlay.Core.Objects;
-using HackenSlay;
 
 namespace HackenSlay.Tests;
 


### PR DESCRIPTION
## Summary
- enable nullable annotations where needed
- correct method overrides in Weapon
- drop unused field
- clean duplicate using

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687826c75d188329b3d1e91e6096e284