### PR TITLE
Update docs with wiki and DevOps tasks info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ whenever you discover new conventions or helpful information.
   - `src/` contains the game source code. Tests live under `src/Tests/HackenSlay.Tests`.
   - `Content/` holds game assets compiled by the MonoGame content pipeline.
   - `docs/knowledge-base/` stores conversation summaries and design decisions.
-  - `Wiki/` hosts additional developer documentation.
+  - `Wiki/` hosts additional developer documentation. The wiki content is stored in the repository root under `Wiki/`.
   - `scripts/` includes helper scripts like `setup.sh` for installing dependencies and building assets.
 
 ## Build and Run
@@ -53,6 +53,7 @@ Cover MapGenerator enemy spawn locations with new unit tests.
 
 ## Documentation Notes
 - When creating Wiki entries, follow the template in `Wiki/leitfaden/chatgpt-kodex.md`.
+- The wiki is maintained in the `Wiki/` directory at the repository root.
 - Conversation summaries in `docs/knowledge-base/` should be named `YYYY-MM-DD-topic.md`.
 Codex scans this folder for background information when generating code.
 

--- a/Wiki/folder-structure.md
+++ b/Wiki/folder-structure.md
@@ -9,7 +9,7 @@ This document describes the layout of the repository after the recent reorganiza
 - `data/` – JSON configuration files for characters, input and other systems.
 - `docs/` – conversation summaries and design notes.
 - `Wiki/` – developer documentation (this folder).
-- `scripts/` – setup and automation scripts.
+- `scripts/` – setup and automation scripts. This folder also contains `active_workitems.json` with the current DevOps tasks.
 
 ## Source folders
 


### PR DESCRIPTION
## Summary
- clarify wiki folder location in `AGENTS.md`
- mention DevOps task JSON in the folder structure wiki page

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68782b0654a88329a7998394c0f808cd