### PR TITLE
Implement simple enemy pathfinding

### DIFF
--- a/docs/knowledge-base/2025-07-12-enemy-ai.md
+++ b/docs/knowledge-base/2025-07-12-enemy-ai.md
@@ -1,0 +1,8 @@
+# Basic Enemy AI
+
+The enemy now uses a simple A* algorithm to chase the player across the tile map.
+
+- `Enemy` calculates a path from its tile position to the player's tile each frame.
+- Movement velocity is derived from the next step in the path.
+- `Pathfinder` implements a minimal A* search over the map generator tiles.
+- Tests verify that obstacles are avoided and the enemy moves toward the player.

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -39,6 +39,8 @@ public class GameHS : Game
     private HackenSlay.UI.Menus.PauseMenu _pauseMenu;
     private RenderTarget2D? _sceneTarget;
     public Vector2 MapSize { get; private set; }
+    public TileType[,] MapTiles => _mapGenerator.Tiles;
+    public int TileSize => _mapGenerator.TileSize;
 
     public GameHS()
     {

--- a/src/Objects/World/Navigation/Pathfinder.cs
+++ b/src/Objects/World/Navigation/Pathfinder.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using HackenSlay.World.Map;
+
+namespace HackenSlay.World.Navigation;
+
+internal static class Pathfinder
+{
+    private readonly struct Node
+    {
+        public readonly Point Pos;
+        public readonly int F;
+        public readonly int G;
+        public Node(Point pos, int g, int f)
+        {
+            Pos = pos;
+            G = g;
+            F = f;
+        }
+    }
+
+    public static List<Point> FindPath(TileType[,] tiles, Point start, Point goal)
+    {
+        int width = tiles.GetLength(0);
+        int height = tiles.GetLength(1);
+        var open = new PriorityQueue<Node, int>();
+        var cameFrom = new Dictionary<Point, Point>();
+        var gScore = new Dictionary<Point, int> { [start] = 0 };
+
+        open.Enqueue(new Node(start, 0, Heuristic(start, goal)), Heuristic(start, goal));
+
+        while (open.Count > 0)
+        {
+            var current = open.Dequeue();
+            if (current.Pos == goal)
+                return Reconstruct(cameFrom, current.Pos);
+
+            foreach (var neighbor in GetNeighbors(current.Pos, width, height))
+            {
+                if (!IsWalkable(tiles, neighbor))
+                    continue;
+
+                int tentative = gScore[current.Pos] + 1;
+                if (!gScore.TryGetValue(neighbor, out int g) || tentative < g)
+                {
+                    cameFrom[neighbor] = current.Pos;
+                    gScore[neighbor] = tentative;
+                    int f = tentative + Heuristic(neighbor, goal);
+                    open.Enqueue(new Node(neighbor, tentative, f), f);
+                }
+            }
+        }
+        return new List<Point>();
+    }
+
+    private static bool IsWalkable(TileType[,] tiles, Point p)
+    {
+        TileType type = tiles[p.X, p.Y];
+        return type != TileType.Obstacle;
+    }
+
+    private static IEnumerable<Point> GetNeighbors(Point p, int width, int height)
+    {
+        if (p.X > 0) yield return new Point(p.X - 1, p.Y);
+        if (p.X < width - 1) yield return new Point(p.X + 1, p.Y);
+        if (p.Y > 0) yield return new Point(p.X, p.Y - 1);
+        if (p.Y < height - 1) yield return new Point(p.X, p.Y + 1);
+    }
+
+    private static int Heuristic(Point a, Point b)
+    {
+        return Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);
+    }
+
+    private static List<Point> Reconstruct(Dictionary<Point, Point> cameFrom, Point current)
+    {
+        var path = new List<Point> { current };
+        while (cameFrom.TryGetValue(current, out var prev))
+        {
+            current = prev;
+            path.Add(current);
+        }
+        path.Reverse();
+        return path;
+    }
+}

--- a/src/Tests/HackenSlay.Tests/EnemyAiTests.cs
+++ b/src/Tests/HackenSlay.Tests/EnemyAiTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.Xna.Framework;
+using HackenSlay;
+using HackenSlay.World.Map;
+using HackenSlay.World.Navigation;
+using Xunit;
+
+namespace HackenSlay.Tests;
+
+public class EnemyAiTests
+{
+    private static TileType[,] CreateSimpleMap()
+    {
+        var tiles = new TileType[3,3];
+        for (int x = 0; x < 3; x++)
+            for (int y = 0; y < 3; y++)
+                tiles[x, y] = TileType.Empty;
+        return tiles;
+    }
+
+    [Fact]
+    public void PathfinderAvoidsObstacles()
+    {
+        var tiles = CreateSimpleMap();
+        tiles[1,0] = TileType.Obstacle;
+        var path = Pathfinder.FindPath(tiles, new Point(0,0), new Point(2,0));
+        Assert.NotEmpty(path);
+        Assert.DoesNotContain(new Point(1,0), path);
+    }
+
+    [Fact]
+    public void EnemyCalculatesVelocityTowardsPlayer()
+    {
+        var tiles = CreateSimpleMap();
+        var enemy = new Enemy("test");
+        enemy._pos = Vector2.Zero;
+        Vector2 vel = enemy.CalculateVelocity(tiles, 1, new Vector2(2,0));
+        Assert.Equal(new Vector2(1,0), vel);
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal A* pathfinder
- expose map info in `GameHS`
- extend `Enemy` with chasing AI
- verify behaviour with new unit tests
- document new enemy AI

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6878301239d083299e01cb6c8fa43a0d