### PR TITLE
Add inventory overlay

### DIFF
--- a/Wiki/UI/inventory-menu.md
+++ b/Wiki/UI/inventory-menu.md
@@ -1,0 +1,6 @@
+# Inventory Menu
+Kurzbeschreibung: Das Inventarmenü listet gesammelte Items des Spielers auf und erlaubt die Auswahl per Tastatur oder Maus.
+
+- Aufruf über die Eingabeaktion `open_inventory`.
+- Pfeiltasten oder Mausklicks ändern die aktuelle Auswahl.
+- Das Menü blendet sich als Overlay ein und pausiert das Spiel nicht.

--- a/src/Core/UI/Menus/InventoryMenu.cs
+++ b/src/Core/UI/Menus/InventoryMenu.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+
+namespace HackenSlay.UI.Menus;
+
+public class InventoryMenu
+{
+    private bool _isVisible;
+    private bool _togglePrev;
+    private Texture2D? _pixel;
+    private Rectangle _bounds;
+    private int _selectedIndex;
+
+    public void LoadContent(GameHS game)
+    {
+        _pixel = new Texture2D(game.GraphicsDevice, 1, 1);
+        _pixel.SetData(new[] { Color.White });
+        int width = 300;
+        int height = 300;
+        _bounds = new Rectangle(
+            game.Window.ClientBounds.Width / 2 - width / 2,
+            game.Window.ClientBounds.Height / 2 - height / 2,
+            width,
+            height);
+    }
+
+    public void Update(GameHS game)
+    {
+        bool pressed = game.userInput.IsActionPressed("open_inventory");
+        if (pressed && !_togglePrev)
+        {
+            _isVisible = !_isVisible;
+        }
+        _togglePrev = pressed;
+
+        if (!_isVisible) return;
+
+        var items = game.player.Inventory.Items;
+        if (items.Count == 0) return;
+
+        KeyboardState ks = Keyboard.GetState();
+        if (ks.IsKeyDown(Keys.Down))
+        {
+            _selectedIndex = Math.Min(_selectedIndex + 1, items.Count - 1);
+        }
+        if (ks.IsKeyDown(Keys.Up))
+        {
+            _selectedIndex = Math.Max(_selectedIndex - 1, 0);
+        }
+
+        MouseState ms = Mouse.GetState();
+        if (ms.LeftButton == ButtonState.Pressed)
+        {
+            int y = _bounds.Y + 20;
+            for (int i = 0; i < items.Count; i++)
+            {
+                Rectangle itemRect = new Rectangle(_bounds.X + 20, y - 4, _bounds.Width - 40, 20);
+                if (itemRect.Contains(ms.Position))
+                {
+                    _selectedIndex = i;
+                    break;
+                }
+                y += 20;
+            }
+        }
+    }
+
+    public void Draw(GameHS game, SpriteBatch spriteBatch)
+    {
+        if (!_isVisible || _pixel == null) return;
+        spriteBatch.Draw(_pixel, _bounds, Color.Black * 0.8f);
+
+        var items = game.player.Inventory.Items;
+        int y = _bounds.Y + 20;
+        for (int i = 0; i < items.Count; i++)
+        {
+            Color color = i == _selectedIndex ? Color.Yellow : Color.White;
+            spriteBatch.DrawString(game._font, items[i]._name, new Vector2(_bounds.X + 20, y), color);
+            y += 20;
+        }
+    }
+
+    public bool IsVisible => _isVisible;
+}

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -37,6 +37,7 @@ public class GameHS : Game
     private DevOverlay _devTool;
     private HackenSlay.UI.Menus.StartMenu _startMenu;
     private HackenSlay.UI.Menus.PauseMenu _pauseMenu;
+    private HackenSlay.UI.Menus.InventoryMenu _inventoryMenu;
     private RenderTarget2D? _sceneTarget;
     public Vector2 MapSize { get; private set; }
 
@@ -61,6 +62,7 @@ public class GameHS : Game
         _devConsole = new DevConsole();
         _startMenu = new HackenSlay.UI.Menus.StartMenu();
         _pauseMenu = new HackenSlay.UI.Menus.PauseMenu();
+        _inventoryMenu = new HackenSlay.UI.Menus.InventoryMenu();
         _camera = new Camera2D();
     }
 
@@ -102,6 +104,7 @@ public class GameHS : Game
         _devConsole.LoadContent(this);
         _startMenu.LoadContent(this);
         _pauseMenu.LoadContent(this);
+        _inventoryMenu.LoadContent(this);
 
         _font = Content.Load<SpriteFont>("fonts/Arial");
     }
@@ -113,6 +116,8 @@ public class GameHS : Game
 
         _startMenu.Update(this);
         _pauseMenu.Update(this, !_startMenu.IsActive);
+        if (!_startMenu.IsActive && !_pauseMenu.IsPaused)
+            _inventoryMenu.Update(this);
 
         if (_startMenu.IsActive || _pauseMenu.IsPaused)
             return;
@@ -164,6 +169,7 @@ public class GameHS : Game
         _spriteBatch.Begin();
         _devTool.Draw(this, _spriteBatch);
         _devConsole.Draw(this, _spriteBatch);
+        _inventoryMenu.Draw(this, _spriteBatch);
         Debug.DrawScreenSize(this, _spriteBatch, _font);
         _spriteBatch.End();
 

--- a/src/Objects/Player/Player.cs
+++ b/src/Objects/Player/Player.cs
@@ -15,6 +15,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using HackenSlay.Core.Objects;
 using HackenSlay.Core.Dev;
+using HackenSlay.Core.Player;
 using Debug = HackenSlay.Core.Dev.Debug;
 
 namespace HackenSlay;
@@ -26,6 +27,7 @@ public class Player : TextureObject
 {
     ItemActionHandler itemActionHandler;
     private Weapon _currentWeapon;
+    public Inventory Inventory { get; } = new Inventory();
 
     public Player(GameHS game) : base()
     {
@@ -37,6 +39,9 @@ public class Player : TextureObject
 
         _isActive = true;
         _isVisible = true;
+
+        // add a placeholder item for testing
+        Inventory.Add(new DummyItem());
     }
 
     public override void LoadContent(GameHS game)


### PR DESCRIPTION
## Summary
- implement simple `InventoryMenu` overlay that lists player's items
- toggle the inventory with the `open_inventory` action
- expose `Inventory` on `Player`
- document inventory menu in wiki

## Testing
- `dotnet build -v minimal`
- `dotnet test --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687830163ca08329852043a8add8eca7