### PR TITLE
Fix AudioManager merge issues

### DIFF
--- a/src/Core/Objects/TextureObject.cs
+++ b/src/Core/Objects/TextureObject.cs
@@ -12,7 +12,6 @@ using Microsoft.Xna.Framework.Input;
 using HackenSlay.Core.Animation;
 using HackenSlay.Audio;
 using HackenSlay.Core.Dev;
-using HackenSlay.Audio;
 
 namespace HackenSlay.Core.Objects;
 

--- a/src/Core/UI/Menus/PauseMenu.cs
+++ b/src/Core/UI/Menus/PauseMenu.cs
@@ -21,7 +21,7 @@ public class PauseMenu
 
     public void LoadContent(GameHS game)
     {
-        _audio.LoadSong(game.Content, "pause", "audio/pause_music");
+        _audio.LoadSong(game.Content, "pauseMusic", "audio/pause_music");
         _pixel = new Texture2D(game.GraphicsDevice, 1, 1);
         _pixel.SetData(new[] { Color.White });
 

--- a/src/Core/UI/Menus/StartMenu.cs
+++ b/src/Core/UI/Menus/StartMenu.cs
@@ -29,10 +29,6 @@ public class StartMenu
         {
             _active = false;
             _audio.StopSong();
-        }
-        else if (_active)
-        {
-            _audio.PlaySong("start");
             _musicPlayed = false;
         }
     }

--- a/src/Objects/Enemy/Enemy.cs
+++ b/src/Objects/Enemy/Enemy.cs
@@ -22,7 +22,7 @@ public class Enemy : TextureObject
     public override void LoadContent(GameHS game)
     {
         base.LoadContent(game);
-        AudioManager.LoadSoundEffect(game.Content, "die", "audio/enemy_die");
+        audioManager.LoadSound(game.Content, "enemy_die", "audio/enemy_die");
     }
 
     public override void Update(GameHS game, GameTime gameTime)
@@ -32,7 +32,6 @@ public class Enemy : TextureObject
             audioManager.PlaySound("enemy_die");
             _isActive = false;
             _isVisible = false;
-            AudioManager.PlaySoundEffect("die");
             return;
         }
 

--- a/src/Objects/Player/Player.cs
+++ b/src/Objects/Player/Player.cs
@@ -56,7 +56,7 @@ public class Player : TextureObject
         animationHandler.LoadContent(game, _animationdata);
         itemActionHandler.LoadContent(game);
         _currentWeapon.LoadContent(game);
-        AudioManager.LoadSoundEffect(game.Content, "attack", "audio/attack");
+        audioManager.LoadSound(game.Content, "player_attack", "audio/attack");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- hook up AudioManager instance in `Player` and `Enemy`
- clean up `StartMenu` logic and fix music names
- fix `PauseMenu` music name
- remove duplicate using directive

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6878e1ee59a883299e907ddad9629160