### PR TITLE
Fix StartMenu drawing

### DIFF
--- a/src/Core/UI/Menus/StartMenu.cs
+++ b/src/Core/UI/Menus/StartMenu.cs
@@ -48,8 +48,11 @@ public class StartMenu : IDisposable
         if (!_active || _pixel == null) return;
         int width = game.GraphicsDevice.PresentationParameters.BackBufferWidth;
         int height = game.GraphicsDevice.PresentationParameters.BackBufferHeight;
+
+        spriteBatch.Begin();
         spriteBatch.Draw(_pixel, new Rectangle(0, 0, width, height), Color.Black * 0.3f);
         spriteBatch.DrawString(game._font, "Start Screen - Press Escape", new Vector2(100, 100), Color.White);
+        spriteBatch.End();
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- fix StartMenu to begin and end the `SpriteBatch` during drawing

## Testing
- `dotnet test --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_68794b4ec7348329a03255546b9dfb37