### PR TITLE
Fix font initialization order

### DIFF
--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -104,11 +104,10 @@ public class GameHS : Game
 
         _devTool.LoadContent(this);
         _devConsole.LoadContent(this);
+        _font = Content.Load<SpriteFont>("fonts/Arial");
         _startMenu.LoadContent(this);
         _pauseMenu.LoadContent(this);
         _inventoryMenu.LoadContent(this);
-
-        _font = Content.Load<SpriteFont>("fonts/Arial");
     }
 
     protected override void Update(GameTime gameTime)


### PR DESCRIPTION
## Summary
- load the default SpriteFont before initializing menus

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68794d14d7dc8329ab5a9b88764587fb