### PR TITLE
Fix pause activation after start menu closes

### DIFF
--- a/src/Core/UI/Menus/StartMenu.cs
+++ b/src/Core/UI/Menus/StartMenu.cs
@@ -12,8 +12,10 @@ public class StartMenu : IDisposable
     private bool _musicPlayed;
     private Texture2D? _pixel;
     private bool _disposed;
+    private bool _justClosed;
 
     public bool IsActive => _active;
+    public bool JustClosed => _justClosed;
 
     public void LoadContent(GameHS game)
     {
@@ -24,6 +26,7 @@ public class StartMenu : IDisposable
 
     public void Update(GameHS game)
     {
+        _justClosed = false;
         if (_active && !_musicPlayed)
         {
             _audio.PlaySong("startMusic");
@@ -35,6 +38,7 @@ public class StartMenu : IDisposable
             _active = false;
             _audio.StopSong();
             Dispose();
+            _justClosed = true;
         }
         else if (_active)
         {

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -117,7 +117,7 @@ public class GameHS : Game
             userInput.ReloadMappings();
 
         _startMenu.Update(this);
-        _pauseMenu.Update(this, !_startMenu.IsActive);
+        _pauseMenu.Update(this, !_startMenu.IsActive && !_startMenu.JustClosed);
         if (!_startMenu.IsActive && !_pauseMenu.IsPaused)
             _inventoryMenu.Update(this);
 


### PR DESCRIPTION
## Summary
- add `JustClosed` flag to `StartMenu`
- ensure `PauseMenu` does not toggle on the same keypress that closes the start menu

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`
- `dotnet run --no-build` *(fails: XDG_RUNTIME_DIR not set)*

------
https://chatgpt.com/codex/tasks/task_e_68794d957460832984b961204ce3e6ce