### PR TITLE
Add default sprite loading for enemies

### DIFF
--- a/src/Objects/Enemy/AlienTypes/Alien.cs
+++ b/src/Objects/Enemy/AlienTypes/Alien.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Alien : Enemy
         _strength = 2;
         _walkspeed = 1.4f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with Alien sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/AlienTypes/Alien_Psi.cs
+++ b/src/Objects/Enemy/AlienTypes/Alien_Psi.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Alien_Psi : Alien
         _strength = 5;
         _walkspeed = 1.2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/AlienTypes/Alien_Scout.cs
+++ b/src/Objects/Enemy/AlienTypes/Alien_Scout.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Alien_Scout : Alien
         _health = 3;
         _walkspeed = 2.2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/AlienTypes/Alien_Warrior.cs
+++ b/src/Objects/Enemy/AlienTypes/Alien_Warrior.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Alien_Warrior : Alien
         _strength = 3;
         _walkspeed = 1.6f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ArcherTypes/Archer.cs
+++ b/src/Objects/Enemy/ArcherTypes/Archer.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Archer : Enemy
         _strength = 2;
         _walkspeed = 1.2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ArcherTypes/Archer_Crossbow.cs
+++ b/src/Objects/Enemy/ArcherTypes/Archer_Crossbow.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Archer_Crossbow : Archer
         _strength = 2;
         _walkspeed = 1.2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ArcherTypes/Archer_Longbow.cs
+++ b/src/Objects/Enemy/ArcherTypes/Archer_Longbow.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Archer_Longbow : Archer
         _strength = 3;
         _walkspeed = 1f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ArcherTypes/Archer_Scout.cs
+++ b/src/Objects/Enemy/ArcherTypes/Archer_Scout.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Archer_Scout : Archer
         _health = 3;
         _walkspeed = 2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/Enemy.cs
+++ b/src/Objects/Enemy/Enemy.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using HackenSlay.Core.Objects;
+using Microsoft.Xna.Framework.Graphics;
 using HackenSlay.World.Map;
 using HackenSlay.World.Navigation;
 
@@ -22,6 +23,7 @@ public class Enemy : TextureObject
     public override void LoadContent(GameHS game)
     {
         base.LoadContent(game);
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
         audioManager.LoadSound(game.Content, "enemy_die", "audio/enemy_die");
     }
 

--- a/src/Objects/Enemy/InsectTypes/Insect.cs
+++ b/src/Objects/Enemy/InsectTypes/Insect.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Insect : Enemy
         _strength = 1;
         _walkspeed = 2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/InsectTypes/Insect_Behemoth.cs
+++ b/src/Objects/Enemy/InsectTypes/Insect_Behemoth.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Insect_Behemoth : Insect
         _strength = 4;
         _walkspeed = 1.5f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/InsectTypes/Insect_Flying.cs
+++ b/src/Objects/Enemy/InsectTypes/Insect_Flying.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Insect_Flying : Insect
         _health = 2;
         _walkspeed = 3f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/InsectTypes/Insect_Swarm.cs
+++ b/src/Objects/Enemy/InsectTypes/Insect_Swarm.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Insect_Swarm : Insect
         _health = 3;
         _walkspeed = 2.5f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/KnightTypes/Knight.cs
+++ b/src/Objects/Enemy/KnightTypes/Knight.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Knight : Enemy
         _strength = 3;
         _walkspeed = 1f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/KnightTypes/Knight_Berserker.cs
+++ b/src/Objects/Enemy/KnightTypes/Knight_Berserker.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Knight_Berserker : Knight
         _strength = 5;
         _walkspeed = 1.2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/KnightTypes/Knight_Elite.cs
+++ b/src/Objects/Enemy/KnightTypes/Knight_Elite.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Knight_Elite : Knight
         _strength = 4;
         _walkspeed = 1.1f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/KnightTypes/Knight_Shielded.cs
+++ b/src/Objects/Enemy/KnightTypes/Knight_Shielded.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Knight_Shielded : Knight
         _health = 10;
         _walkspeed = 0.8f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/MummyTypes/Mummy.cs
+++ b/src/Objects/Enemy/MummyTypes/Mummy.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Mummy : Enemy
         _strength = 2;
         _walkspeed = 0.7f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/MummyTypes/Mummy_Ancient.cs
+++ b/src/Objects/Enemy/MummyTypes/Mummy_Ancient.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Mummy_Ancient : Mummy
         _health = 12;
         _walkspeed = 0.6f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/MummyTypes/Mummy_Cursed.cs
+++ b/src/Objects/Enemy/MummyTypes/Mummy_Cursed.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -10,4 +12,12 @@ public class Mummy_Cursed : Mummy
         _name = "Cursed Mummy";
         _strength = 4;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/MummyTypes/Mummy_Swift.cs
+++ b/src/Objects/Enemy/MummyTypes/Mummy_Swift.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Mummy_Swift : Mummy
         _health = 6;
         _walkspeed = 1.2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/RobotTypes/Robot.cs
+++ b/src/Objects/Enemy/RobotTypes/Robot.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Robot : Enemy
         _strength = 4;
         _walkspeed = 0.9f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/RobotTypes/Robot_Assault.cs
+++ b/src/Objects/Enemy/RobotTypes/Robot_Assault.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Robot_Assault : Robot
         _strength = 5;
         _walkspeed = 1f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/RobotTypes/Robot_Sniper.cs
+++ b/src/Objects/Enemy/RobotTypes/Robot_Sniper.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Robot_Sniper : Robot
         _strength = 6;
         _walkspeed = 0.7f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/RobotTypes/Robot_Tank.cs
+++ b/src/Objects/Enemy/RobotTypes/Robot_Tank.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Robot_Tank : Robot
         _strength = 4;
         _walkspeed = 0.5f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/SoldierTypes/Soldier.cs
+++ b/src/Objects/Enemy/SoldierTypes/Soldier.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Soldier : Enemy
         _strength = 3;
         _walkspeed = 1.3f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/SoldierTypes/Soldier_Commander.cs
+++ b/src/Objects/Enemy/SoldierTypes/Soldier_Commander.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Soldier_Commander : Soldier
         _health = 7;
         _strength = 4;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/SoldierTypes/Soldier_Heavy.cs
+++ b/src/Objects/Enemy/SoldierTypes/Soldier_Heavy.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Soldier_Heavy : Soldier
         _strength = 5;
         _walkspeed = 0.9f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/SoldierTypes/Soldier_Infantry.cs
+++ b/src/Objects/Enemy/SoldierTypes/Soldier_Infantry.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -9,4 +11,12 @@ public class Soldier_Infantry : Soldier
     {
         _name = "Infantry Soldier";
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ZombieTypes/Zombie.cs
+++ b/src/Objects/Enemy/ZombieTypes/Zombie.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 using Microsoft.Xna.Framework;
 
 namespace HackenSlay;
@@ -13,4 +15,12 @@ public class Zombie : Enemy
         _strength = 1;
         _walkspeed = 1f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ZombieTypes/Zombie_Armed.cs
+++ b/src/Objects/Enemy/ZombieTypes/Zombie_Armed.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Zombie_Armed : Zombie
         _health = 5;
         _strength = 2;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ZombieTypes/Zombie_Fast.cs
+++ b/src/Objects/Enemy/ZombieTypes/Zombie_Fast.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Zombie_Fast : Zombie
         _health = 4;
         _walkspeed = 2f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ZombieTypes/Zombie_Juggernaut.cs
+++ b/src/Objects/Enemy/ZombieTypes/Zombie_Juggernaut.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -12,4 +14,12 @@ public class Zombie_Juggernaut : Zombie
         _walkspeed = 0.8f;
         _strength = 3;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }

--- a/src/Objects/Enemy/ZombieTypes/Zombie_Slow.cs
+++ b/src/Objects/Enemy/ZombieTypes/Zombie_Slow.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace HackenSlay;
 
 /// <summary>
@@ -11,4 +13,12 @@ public class Zombie_Slow : Zombie
         _health = 6;
         _walkspeed = 0.5f;
     }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+        // UserTodo: replace with correct sprite
+        _sprite = game.Content.Load<Texture2D>("sprites/missing");
+    }
+
 }


### PR DESCRIPTION
## Summary
- add `_sprite` loader in `Enemy` base so enemies get a default texture
- load placeholder sprite in each enemy subclass for easy customization

## Testing
- `./scripts/setup.sh --build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687a77f111bc8329a235966dd41fc9c8