### PR TITLE
Refactor JSON loading into core helper

### DIFF
--- a/src/Core/IO/JSONHandler.cs
+++ b/src/Core/IO/JSONHandler.cs
@@ -5,12 +5,42 @@
 //Todo: Add XML documentation to all methods and properties
 //Todo: move / refactor this file into the fitting category and folder structure
 
-namespace HackenSlay.Core.Networking;
+using System.IO;
+using System.Text.Json;
+
+namespace HackenSlay.Core.IO;
 
 /// <summary>
 /// Static utilities for reading and writing JSON files.
 /// </summary>
 public static class JSONHandler
 {
+    /// <summary>
+    /// Reads the given JSON file and deserializes it into a <see cref="JsonDocument"/>.
+    /// </summary>
+    /// <param name="filePath">Path to the JSON file.</param>
+    /// <returns>The parsed <see cref="JsonDocument"/> or <c>null</c> if the file does not exist.</returns>
+    public static JsonDocument? LoadDocument(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return null;
 
+        string json = File.ReadAllText(filePath);
+        return JsonDocument.Parse(json);
+    }
+
+    /// <summary>
+    /// Reads the given JSON file and deserializes it to the specified type.
+    /// </summary>
+    /// <typeparam name="T">Target type for deserialization.</typeparam>
+    /// <param name="filePath">Path to the JSON file.</param>
+    /// <returns>The deserialized object or <c>null</c> if the file does not exist.</returns>
+    public static T? Load<T>(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return default;
+
+        string json = File.ReadAllText(filePath);
+        return JsonSerializer.Deserialize<T>(json);
+    }
 }

--- a/src/Core/Input/InputMapping.cs
+++ b/src/Core/Input/InputMapping.cs
@@ -37,8 +37,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text.Json;
+using HackenSlay.Core.IO;
 using Microsoft.Xna.Framework.Input;
 
 namespace HackenSlay
@@ -79,8 +78,7 @@ namespace HackenSlay
         {
             try
             {
-                string json = File.ReadAllText(filePath);
-                var rawMapping = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(json);
+                var rawMapping = JSONHandler.Load<Dictionary<string, List<string>>>(filePath);
 
                 if (rawMapping == null) return;
 

--- a/src/Objects/Player/Player.cs
+++ b/src/Objects/Player/Player.cs
@@ -3,8 +3,8 @@
 /// </summary>
 
 using System;
-using System.IO;
 using System.Text.Json;
+using HackenSlay.Core.IO;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using HackenSlay.Core.Objects;
@@ -207,29 +207,24 @@ public class Player : TextureObject
     /// <param name="playerData">Path to the JSON file.</param>
     private void LoadJSON(string playerData)
     {
+        using JsonDocument? doc = JSONHandler.LoadDocument(playerData);
+        if (doc == null)
+            return;
 
-        if (File.Exists(playerData))
-        {
-            string jsonString = File.ReadAllText(playerData);
+        JsonElement root = doc.RootElement;
 
-            using (JsonDocument doc = JsonDocument.Parse(jsonString))
-            {
-                JsonElement root = doc.RootElement;
+        _name = root.GetProperty("name").GetString();
+        _health = root.GetProperty("health").GetInt32();
+        _strength = root.GetProperty("strength").GetInt32();
+        _animationdata = root.GetProperty("animationdata").GetString();
+        _walkspeed = (float)root.GetProperty("walkspeed").GetDouble();
+        _runspeed = (float)root.GetProperty("runspeed").GetDouble();
 
-                _name = root.GetProperty("name").GetString();
-                _health = root.GetProperty("health").GetInt32();
-                _strength = root.GetProperty("strength").GetInt32();
-                _animationdata = root.GetProperty("animationdata").GetString();
-                _walkspeed = (float)root.GetProperty("walkspeed").GetDouble();
-                _runspeed = (float)root.GetProperty("runspeed").GetDouble();
-
-                Debug.Log($"Name: {_name}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
-                Debug.Log($"Health: {_health}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
-                Debug.Log($"Strength: {_strength}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
-                Debug.Log($"Animation Data: {_animationdata}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
-                Debug.Log($"walkspeed: {_walkspeed}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
-                Debug.Log($"runspeed: {_runspeed}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
-            }
-        }
+        Debug.Log($"Name: {_name}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
+        Debug.Log($"Health: {_health}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
+        Debug.Log($"Strength: {_strength}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
+        Debug.Log($"Animation Data: {_animationdata}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
+        Debug.Log($"walkspeed: {_walkspeed}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
+        Debug.Log($"runspeed: {_runspeed}", DebugLevel.HIGH, DebugCategory.PLAYERCALC);
     }
 }


### PR DESCRIPTION
## Summary
- create `JSONHandler` with reusable load functions
- update `Player` to use the new helper
- load input mappings via `JSONHandler`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687ab255d8a48329bbb8b510f8c3203a