### PR TITLE
Add biome weights to map generator

### DIFF
--- a/Wiki/World/MapGenerator.md
+++ b/Wiki/World/MapGenerator.md
@@ -10,18 +10,21 @@ This document summarizes how maps are created in `src/Objects/World/Map/MapGener
 
 2. **Street Generation** (`GenerateStreets`)
    - Begins in the center of the grid.
-   - Performs a random walk for `width * height` steps.
+   - Performs a random walk for `width * height` steps multiplied by a biome weight.
    - Each step chooses one of the four directions and clamps the position to the grid bounds.
    - Tiles visited during the walk become `TileType.Street`.
 
 3. **Obstacle Placement** (`PlaceObstacles`)
-   - Picks a random percentage between 10% and 20% for obstacle density.
+   - Picks a random percentage between 10% and 20% for obstacle density and scales it with the biome weight.
    - Iterates over all tiles and converts some of the remaining `Empty` ones into `Obstacle` based on that chance.
 
 4. **Enemy Spawns** (`PlaceEnemySpawns`)
    - Calculates the number of spawns as `max(1, (width + height) / 20)`.
    - Attempts random positions until the required count is placed or 1000 attempts were made.
    - Only empty tiles on the outer edges of the map become `EnemySpawn` tiles.
+
+5. **Structure Spawns** (`PlaceStructureSpawns`)
+   - Determines the amount of structures as `max(1, (width + height) / 30)` multiplied by the biome weight.
 
 The `Draw` method simply colors the generated tiles for visualization and is not used by the tests.
 

--- a/src/Objects/World/Map/BiomeWeights.cs
+++ b/src/Objects/World/Map/BiomeWeights.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace HackenSlay.World.Map;
+
+public record BiomeWeights(double StreetStepsFactor, double ObstacleFactor, double StructureFactor)
+{
+    public static readonly Dictionary<BiomeType, BiomeWeights> Presets = new()
+    {
+        { BiomeType.Plains, new BiomeWeights(1.0, 1.0, 1.0) },
+        { BiomeType.Desert, new BiomeWeights(0.5, 0.3, 0.5) },
+        { BiomeType.Forest, new BiomeWeights(1.0, 2.0, 1.0) },
+        { BiomeType.Snow,   new BiomeWeights(0.8, 0.7, 0.8) }
+    };
+}

--- a/src/Objects/World/Map/MapGenerator.cs
+++ b/src/Objects/World/Map/MapGenerator.cs
@@ -13,6 +13,7 @@ public class MapGenerator
     public int Height { get; }
     public int TileSize { get; }
     public BiomeType Biome { get; }
+    private readonly BiomeWeights _weights;
 
     private readonly Random _random;
     private readonly Texture2D? _pixel;
@@ -23,6 +24,7 @@ public class MapGenerator
         Height = height;
         TileSize = tileSize;
         Biome = biome;
+        _weights = BiomeWeights.Presets.TryGetValue(biome, out var w) ? w : BiomeWeights.Presets[BiomeType.Plains];
         _random = seed.HasValue ? new Random(seed.Value) : new Random();
         if (graphicsDevice != null)
         {
@@ -50,7 +52,7 @@ public class MapGenerator
     {
         int x = Width / 2;
         int y = Height / 2;
-        int steps = Width * Height;
+        int steps = (int)(Width * Height * _weights.StreetStepsFactor);
         Tiles[x, y] = TileType.Street;
 
         for (int i = 0; i < steps; i++)
@@ -71,7 +73,7 @@ public class MapGenerator
 
     private void PlaceObstacles()
     {
-        double obstacleChance = _random.Next(10, 21) / 100.0; // between 10% and 20%
+        double obstacleChance = _random.Next(10, 21) / 100.0 * _weights.ObstacleFactor; // weighted chance
         for (int x = 0; x < Width; x++)
         {
             for (int y = 0; y < Height; y++)
@@ -104,7 +106,7 @@ public class MapGenerator
 
     private void PlaceStructureSpawns()
     {
-        int structures = Math.Max(1, (Width + Height) / 30);
+        int structures = (int)Math.Max(1, (Width + Height) / 30.0 * _weights.StructureFactor);
         for (int i = 0; i < structures; i++)
         {
             int x = _random.Next(Width);

--- a/src/Tests/HackenSlay.Tests/MapGeneratorTests.cs
+++ b/src/Tests/HackenSlay.Tests/MapGeneratorTests.cs
@@ -19,4 +19,14 @@ public class MapGeneratorTests
         var gen = new MapGenerator(null, 10, 10, 1, seed: 42);
         Assert.Contains(TileType.EnemySpawn, gen.Tiles.Cast<TileType>());
     }
+
+    [Fact]
+    public void DesertHasFewerObstaclesThanForest()
+    {
+        var desert = new MapGenerator(null, 20, 20, 1, seed: 42, biome: BiomeType.Desert);
+        var forest = new MapGenerator(null, 20, 20, 1, seed: 42, biome: BiomeType.Forest);
+        int desertObstacles = desert.Tiles.Cast<TileType>().Count(t => t == TileType.Obstacle);
+        int forestObstacles = forest.Tiles.Cast<TileType>().Count(t => t == TileType.Obstacle);
+        Assert.True(desertObstacles < forestObstacles);
+    }
 }


### PR DESCRIPTION
## Summary
- control street steps, obstacle chance and structure count via `BiomeWeights`
- reference preset weights for each biome
- describe new weighting in MapGenerator wiki page
- test desert vs forest obstacle density

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687ac53dbf588329bfca2521e6354977