### PR TITLE
Add tangible obstacles and structure spawns

### DIFF
--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -93,6 +93,10 @@ public class GameHS : Game
         // create map after graphics device is ready
         _mapGenerator = new MapGenerator(GraphicsDevice, 50, 50, 64);
         _tileMap = WorldBuilder.Build(GraphicsDevice, _mapGenerator);
+        foreach (var obj in WorldBuilder.BuildObjects(_mapGenerator))
+        {
+            AddObject(obj);
+        }
         MapSize = new Vector2(
             _mapGenerator.Width * _mapGenerator.TileSize,
             _mapGenerator.Height * _mapGenerator.TileSize);

--- a/src/Objects/World/Map/WorldBuilder.cs
+++ b/src/Objects/World/Map/WorldBuilder.cs
@@ -1,4 +1,10 @@
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using HackenSlay.Core.Objects;
+using HackenSlay.World.Terrain;
+using HackenSlay.World.Tiles;
+using HackenSlay.World.Structures;
 
 namespace HackenSlay.World.Map;
 
@@ -8,5 +14,43 @@ public static class WorldBuilder
     {
         var atlas = TileAtlas.Create(device, generator.TileSize);
         return new TileMap(generator.Tiles, atlas, generator.TileSize);
+    }
+
+    public static List<TextureObject> BuildObjects(MapGenerator generator)
+    {
+        var objects = new List<TextureObject>();
+        for (int x = 0; x < generator.Width; x++)
+        {
+            for (int y = 0; y < generator.Height; y++)
+            {
+                TileType type = generator.Tiles[x, y];
+                if (type == TileType.Empty || type == TileType.Street)
+                    continue;
+
+                Vector2 pos = new Vector2(x * generator.TileSize, y * generator.TileSize);
+                switch (type)
+                {
+                    case TileType.Obstacle:
+                        var obstacle = new Obstacle();
+                        obstacle._pos = pos;
+                        obstacle.Size = new Vector2(generator.TileSize, generator.TileSize);
+                        objects.Add(obstacle);
+                        break;
+                    case TileType.EnemySpawn:
+                        var spawn = new EnemySpawnTile();
+                        spawn._pos = pos;
+                        spawn.Size = new Vector2(generator.TileSize, generator.TileSize);
+                        objects.Add(spawn);
+                        break;
+                    case TileType.StructureSpawn:
+                        var block = new SpawnBlock("default");
+                        block._pos = pos;
+                        block.Size = new Vector2(generator.TileSize, generator.TileSize);
+                        objects.Add(block);
+                        break;
+                }
+            }
+        }
+        return objects;
     }
 }

--- a/src/Objects/World/Structures/SpawnBlock.cs
+++ b/src/Objects/World/Structures/SpawnBlock.cs
@@ -1,6 +1,9 @@
+// Erstellt mit Unterstützung von OpenAI Codex
+using HackenSlay.World.Terrain;
+
 namespace HackenSlay.World.Structures;
 
-public class SpawnBlock
+public class SpawnBlock : TerrainObject
 {
     public string StructureName { get; }
     public SpawnBlock(string structureName)

--- a/src/Objects/World/Tiles/EnemySpawnTile.cs
+++ b/src/Objects/World/Tiles/EnemySpawnTile.cs
@@ -1,0 +1,13 @@
+// Erstellt mit Unterstützung von OpenAI Codex
+using HackenSlay.Core.Objects;
+
+namespace HackenSlay.World.Tiles;
+
+public class EnemySpawnTile : TextureObject
+{
+    public EnemySpawnTile()
+    {
+        IsMovable = false;
+        IsIntangible = true;
+    }
+}

--- a/src/Objects/World/Tiles/StreetTile.cs
+++ b/src/Objects/World/Tiles/StreetTile.cs
@@ -1,0 +1,13 @@
+// Erstellt mit Unterstützung von OpenAI Codex
+using HackenSlay.Core.Objects;
+
+namespace HackenSlay.World.Tiles;
+
+public class StreetTile : TextureObject
+{
+    public StreetTile()
+    {
+        IsMovable = false;
+        IsIntangible = true;
+    }
+}

--- a/src/Tests/HackenSlay.Tests/WorldBuilderTests.cs
+++ b/src/Tests/HackenSlay.Tests/WorldBuilderTests.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using HackenSlay.World.Map;
+using HackenSlay.World.Terrain;
+using HackenSlay.World.Structures;
+using Xunit;
+
+namespace HackenSlay.Tests;
+
+public class WorldBuilderTests
+{
+    [Fact]
+    public void BuildObjectsCreatesTangibleObstaclesAndStructureSpawns()
+    {
+        var gen = new MapGenerator(null, 50, 50, 1, seed: 42);
+        var objects = WorldBuilder.BuildObjects(gen);
+        Assert.Contains(objects.OfType<Obstacle>(), o => !o.IsIntangible);
+        Assert.Contains(objects.OfType<SpawnBlock>(), s => !s.IsIntangible);
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate tile types into new GameObject system
- build tangible obstacle and structure spawn objects
- expose world objects during game load
- cover WorldBuilder object creation in tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687ac4ec699c83299c85e4705cfe0e89