### PR TITLE
Implement Food items

### DIFF
--- a/src/Core/Dev/DevSpawner.cs
+++ b/src/Core/Dev/DevSpawner.cs
@@ -14,11 +14,14 @@ public static class DevSpawner
         };
     }
 
-    public static Item SpawnItem(string itemName)
+    public static Item SpawnItem(Player player, string itemName)
     {
         return itemName.ToLower() switch
         {
             "dummy" => new DummyItem(),
+            "bread" => new Bread(player),
+            "apple" => new Apple(player),
+            "meat" => new Meat(player),
             _ => null
         };
     }

--- a/src/Core/UI/Menus/DevConsole.cs
+++ b/src/Core/UI/Menus/DevConsole.cs
@@ -104,7 +104,7 @@ public class DevConsole
                             }
                             break;
                         case "item":
-                            var item = DevSpawner.SpawnItem(name);
+                            var item = DevSpawner.SpawnItem(_game.player, name);
                             if (item != null)
                             {
                                 _game.AddObject(item);

--- a/src/Objects/Items/Collectibles/Food.cs
+++ b/src/Objects/Items/Collectibles/Food.cs
@@ -1,9 +1,0 @@
-namespace HackenSlay;
-
-public class Food : Collectible
-{
-    public Food(Player player) : base(player)
-    {
-
-    }
-}

--- a/src/Objects/Items/DummyItem.cs
+++ b/src/Objects/Items/DummyItem.cs
@@ -10,11 +10,11 @@ public class DummyItem : Item
         _name = "DummyItem";
     }
 
-    public override void Update(GameTime gameTime)
+    public override void Update(GameHS game, GameTime gameTime)
     {
     }
 
-    public override void Draw(SpriteBatch spriteBatch, Player player)
+    public override void Draw(GameHS game, SpriteBatch spriteBatch)
     {
     }
 

--- a/src/Objects/Items/Food/Apple.cs
+++ b/src/Objects/Items/Food/Apple.cs
@@ -1,0 +1,12 @@
+namespace HackenSlay;
+
+/// <summary>
+/// Juicy apple restoring a small amount of health.
+/// </summary>
+public class Apple : Food
+{
+    public Apple(Player player) : base(player, 5)
+    {
+        _name = "Apple";
+    }
+}

--- a/src/Objects/Items/Food/Bread.cs
+++ b/src/Objects/Items/Food/Bread.cs
@@ -1,0 +1,12 @@
+namespace HackenSlay;
+
+/// <summary>
+/// Simple bread restoring a small amount of health.
+/// </summary>
+public class Bread : Food
+{
+    public Bread(Player player) : base(player, 10)
+    {
+        _name = "Bread";
+    }
+}

--- a/src/Objects/Items/Food/Food.cs
+++ b/src/Objects/Items/Food/Food.cs
@@ -1,0 +1,71 @@
+namespace HackenSlay;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+/// <summary>
+/// Base class for consumable food items that restore player health.
+/// </summary>
+public abstract class Food : Item
+{
+    /// <summary>
+    /// Amount of health restored when consumed.
+    /// </summary>
+    public int HealAmount { get; }
+    private readonly Player _player;
+
+    protected Food(Player player, int healAmount)
+        : base()
+    {
+        _player = player;
+        HealAmount = healAmount;
+        _isActive = true;
+        _isVisible = true;
+        Size = new Vector2(16, 16);
+    }
+
+    public override void LoadContent(GameHS game)
+    {
+        base.LoadContent(game);
+    }
+
+    public override void Update(GameHS game, GameTime gameTime)
+    {
+        if (!_isActive)
+            return;
+
+        var player = _player ?? game?.player;
+        if (player == null)
+            return;
+
+        Rectangle itemRect = new Rectangle((int)_pos.X, (int)_pos.Y, (int)Size.X, (int)Size.Y);
+        Rectangle playerRect = new Rectangle((int)player._pos.X, (int)player._pos.Y, (int)player.Size.X, (int)player.Size.Y);
+        if (itemRect.Intersects(playerRect))
+        {
+            player.Inventory.Add(this);
+            _isActive = false;
+            _isVisible = false;
+        }
+    }
+
+    public override void Draw(GameHS game, SpriteBatch spriteBatch)
+    {
+        if (!_isVisible)
+            return;
+
+        spriteBatch.Draw(_sprite, _pos, Color.White);
+    }
+
+    /// <summary>
+    /// Consume the food item and heal the player.
+    /// </summary>
+    public override void Handle(GameHS game)
+    {
+        var player = _player ?? game?.player;
+        if (player == null)
+            return;
+
+        player._health += HealAmount;
+        player.Inventory.Remove(this);
+    }
+}

--- a/src/Objects/Items/Food/Meat.cs
+++ b/src/Objects/Items/Food/Meat.cs
@@ -1,0 +1,12 @@
+namespace HackenSlay;
+
+/// <summary>
+/// Hearty meat restoring a larger amount of health.
+/// </summary>
+public class Meat : Food
+{
+    public Meat(Player player) : base(player, 20)
+    {
+        _name = "Meat";
+    }
+}

--- a/src/Objects/Items/Item.cs
+++ b/src/Objects/Items/Item.cs
@@ -12,8 +12,8 @@ namespace HackenSlay
         {
         }
 
-        public abstract void Update(GameTime gameTime);
-        public abstract void Draw(SpriteBatch spriteBatch, Player player);
+        public abstract override void Update(GameHS game, GameTime gameTime);
+        public abstract override void Draw(GameHS game, SpriteBatch spriteBatch);
         public abstract void Handle(GameHS game);
     }
 }

--- a/src/Tests/HackenSlay.Tests/FoodTests.cs
+++ b/src/Tests/HackenSlay.Tests/FoodTests.cs
@@ -1,0 +1,42 @@
+using HackenSlay;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace HackenSlay.Tests;
+
+public class FoodTests
+{
+    [Fact]
+    public void HandleRestoresHealthAndRemovesFromInventory()
+    {
+        var player = new Player(null);
+        player.Inventory.Add(new DummyItem()); // ensure inventory not empty
+        int start = player._health;
+        var bread = new Bread(player);
+        player.Inventory.Add(bread);
+
+        bread.Handle(null);
+
+        Assert.Equal(start + bread.HealAmount, player._health);
+        Assert.DoesNotContain(bread, player.Inventory.Items);
+    }
+
+    [Fact]
+    public void UpdateAddsFoodToInventoryOnCollision()
+    {
+        var player = new Player(null);
+        player.Size = new Vector2(10, 10);
+        player._pos = Vector2.Zero;
+        var apple = new Apple(player)
+        {
+            Size = new Vector2(10, 10),
+            _pos = Vector2.Zero
+        };
+
+        apple.Update(null, new GameTime());
+
+        Assert.Contains(apple, player.Inventory.Items);
+        Assert.False(apple._isActive);
+        Assert.False(apple._isVisible);
+    }
+}

--- a/src/Tests/HackenSlay.Tests/ItemActionHandlerTests.cs
+++ b/src/Tests/HackenSlay.Tests/ItemActionHandlerTests.cs
@@ -15,8 +15,8 @@ public class ItemActionHandlerTests
         {
             _isActive = true;
         }
-        public override void Update(GameTime gameTime) { }
-        public override void Draw(SpriteBatch spriteBatch, Player player) { }
+        public override void Update(GameHS game, GameTime gameTime) { }
+        public override void Draw(GameHS game, SpriteBatch spriteBatch) { }
         public override void Handle(GameHS game) { Handled = true; }
     }
 


### PR DESCRIPTION
## Summary
- add base class `Food` inheriting from `Item`
- implement three food types: `Bread`, `Apple`, `Meat`
- spawn food via `DevSpawner`
- adjust console command to create food items
- update item API and dummy implementations
- add unit tests for food behaviour

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687ac5ba85608329b76822c08e64c435