### PR TITLE
Add HUD overlay with minimap

### DIFF
--- a/src/Core/UI/HUD/GameHud.cs
+++ b/src/Core/UI/HUD/GameHud.cs
@@ -1,0 +1,93 @@
+// Erstellt mit Unterstützung von OpenAI Codex
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using HackenSlay.World.Map;
+
+namespace HackenSlay.UI.HUD;
+
+public class GameHud
+{
+    private Texture2D? _pixel;
+    private Rectangle[] _hotbars = Array.Empty<Rectangle>();
+    private Rectangle _primary;
+    private Rectangle _secondary;
+    private Minimap _minimap;
+
+    public GameHud(GameHS game)
+    {
+        _minimap = new Minimap(game);
+    }
+
+    public void LoadContent(GameHS game, MapGenerator generator)
+    {
+        _pixel = new Texture2D(game.GraphicsDevice, 1, 1);
+        _pixel.SetData(new[] { Color.White });
+
+        int size = 48;
+        int padding = 10;
+        int bottom = game.GraphicsDevice.PresentationParameters.BackBufferHeight - size - padding;
+        _hotbars = new Rectangle[4];
+        for (int i = 0; i < 4; i++)
+        {
+            int x = padding + i * (size + padding);
+            _hotbars[i] = new Rectangle(x, bottom, size, size);
+        }
+        _primary = new Rectangle(padding, bottom - size - padding, size, size);
+        _secondary = new Rectangle(padding + size + padding, bottom - size - padding, size, size);
+
+        _minimap.LoadContent(game, generator);
+    }
+
+    public void Update(GameHS game, GameTime gameTime)
+    {
+        // currently no logic needed
+    }
+
+    private static Rectangle Fit(Texture2D tex, Rectangle bounds)
+    {
+        float scale = Math.Min((float)bounds.Width / tex.Width, (float)bounds.Height / tex.Height);
+        int w = (int)(tex.Width * scale);
+        int h = (int)(tex.Height * scale);
+        int x = bounds.X + (bounds.Width - w) / 2;
+        int y = bounds.Y + (bounds.Height - h) / 2;
+        return new Rectangle(x, y, w, h);
+    }
+
+    public void Draw(GameHS game, SpriteBatch spriteBatch)
+    {
+        if (_pixel == null) return;
+
+        spriteBatch.DrawString(game._font, $"HP: {game.player._health}", new Vector2(10, 10), Color.White);
+
+        for (int i = 0; i < _hotbars.Length; i++)
+        {
+            spriteBatch.Draw(_pixel, _hotbars[i], Color.Black * 0.5f);
+            if (game.player.Inventory.Items.Count > i)
+            {
+                var item = game.player.Inventory.Items[i];
+                var tex = item._sprite;
+                if (tex != null)
+                {
+                    spriteBatch.Draw(tex, Fit(tex, _hotbars[i]), Color.White);
+                }
+            }
+        }
+
+        spriteBatch.Draw(_pixel, _primary, Color.Black * 0.5f);
+        var primaryWeapon = game.player.CurrentWeapon;
+        if (primaryWeapon?._sprite != null)
+        {
+            spriteBatch.Draw(primaryWeapon._sprite, Fit(primaryWeapon._sprite, _primary), Color.White);
+        }
+
+        spriteBatch.Draw(_pixel, _secondary, Color.Black * 0.5f);
+        // currently using same weapon for secondary
+        if (primaryWeapon?._sprite != null)
+        {
+            spriteBatch.Draw(primaryWeapon._sprite, Fit(primaryWeapon._sprite, _secondary), Color.White);
+        }
+
+        _minimap.Draw(spriteBatch);
+    }
+}

--- a/src/Core/UI/HUD/Minimap.cs
+++ b/src/Core/UI/HUD/Minimap.cs
@@ -1,0 +1,35 @@
+// Erstellt mit Unterstützung von OpenAI Codex
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using HackenSlay.World.Map;
+
+namespace HackenSlay.UI.HUD;
+
+public class Minimap
+{
+    private Texture2D? _mapTexture;
+    private Rectangle _bounds;
+
+    public Minimap(GameHS game)
+    {
+        int size = 150;
+        _bounds = new Rectangle(
+            game.GraphicsDevice.PresentationParameters.BackBufferWidth - size - 10,
+            10,
+            size,
+            size);
+    }
+
+    public void LoadContent(GameHS game, MapGenerator generator)
+    {
+        _mapTexture = generator.CreateMinimapTexture(game.GraphicsDevice);
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        if (_mapTexture != null)
+        {
+            spriteBatch.Draw(_mapTexture, _bounds, Color.White);
+        }
+    }
+}

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -14,6 +14,7 @@ using HackenSlay.UI.Menus;
 using HackenSlay.Core.Objects;
 using HackenSlay.Core.Animation;
 using HackenSlay.Core.Dev;
+using HackenSlay.UI.HUD;
 
 namespace HackenSlay;
 
@@ -38,6 +39,7 @@ public class GameHS : Game
     private StartMenu _startMenu;
     private PauseMenu _pauseMenu;
     private InventoryMenu _inventoryMenu;
+    private GameHud _hud;
     private RenderTarget2D? _sceneTarget;
     public Vector2 MapSize { get; private set; }
     public TileType[,] MapTiles => _mapGenerator.Tiles;
@@ -66,6 +68,7 @@ public class GameHS : Game
         _pauseMenu = new PauseMenu();
         _inventoryMenu = new InventoryMenu();
         _camera = new Camera2D();
+        _hud = new GameHud(this);
     }
 
     protected override void Initialize()
@@ -108,6 +111,7 @@ public class GameHS : Game
         _startMenu.LoadContent(this);
         _pauseMenu.LoadContent(this);
         _inventoryMenu.LoadContent(this);
+        _hud.LoadContent(this, _mapGenerator);
     }
 
     protected override void Update(GameTime gameTime)
@@ -128,6 +132,7 @@ public class GameHS : Game
 
         _devTool.Update(this, gameTime);
         _devConsole.Update(this, gameTime);
+        _hud.Update(this, gameTime);
 
         base.Update(gameTime);
     }
@@ -171,6 +176,7 @@ public class GameHS : Game
         _devTool.Draw(this, _spriteBatch);
         _devConsole.Draw(this, _spriteBatch);
         _inventoryMenu.Draw(this, _spriteBatch);
+        _hud.Draw(this, _spriteBatch);
         Debug.DrawScreenSize(this, _spriteBatch, _font);
         _spriteBatch.End();
 

--- a/src/Objects/Player/Player.cs
+++ b/src/Objects/Player/Player.cs
@@ -22,6 +22,7 @@ public class Player : AnimationObject
     ItemActionHandler itemActionHandler;
     private Weapon _currentWeapon;
     public Inventory Inventory { get; } = new Inventory();
+    public Weapon CurrentWeapon => _currentWeapon;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Player"/> class.

--- a/src/Objects/World/Map/MapGenerator.cs
+++ b/src/Objects/World/Map/MapGenerator.cs
@@ -144,4 +144,27 @@ public class MapGenerator
             }
         }
     }
+
+    public Texture2D CreateMinimapTexture(GraphicsDevice device)
+    {
+        var texture = new Texture2D(device, Width, Height);
+        var data = new Color[Width * Height];
+        for (int x = 0; x < Width; x++)
+        {
+            for (int y = 0; y < Height; y++)
+            {
+                Color color = Tiles[x, y] switch
+                {
+                    TileType.Street => Color.Gray,
+                    TileType.Obstacle => Color.DarkGray,
+                    TileType.EnemySpawn => Color.Red,
+                    TileType.StructureSpawn => Color.Green,
+                    _ => Color.Black
+                };
+                data[y * Width + x] = color;
+            }
+        }
+        texture.SetData(data);
+        return texture;
+    }
 }


### PR DESCRIPTION
## Summary
- expose `CurrentWeapon` on `Player`
- add minimap texture generation to `MapGenerator`
- implement new `GameHud` and `Minimap` classes
- integrate HUD into `GameHS`

## Testing
- `./scripts/setup.sh --build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_687ac62601bc83298470169848297c45