### PR TITLE
Add draggable inventory grid

### DIFF
--- a/src/Core/UI/HUD/GameHud.cs
+++ b/src/Core/UI/HUD/GameHud.cs
@@ -82,10 +82,10 @@ public class GameHud
         }
 
         spriteBatch.Draw(_pixel, _secondary, Color.Black * 0.5f);
-        // currently using same weapon for secondary
-        if (primaryWeapon?._sprite != null)
+        var secondaryWeapon = game.player.SecondaryWeapon;
+        if (secondaryWeapon?._sprite != null)
         {
-            spriteBatch.Draw(primaryWeapon._sprite, Fit(primaryWeapon._sprite, _secondary), Color.White);
+            spriteBatch.Draw(secondaryWeapon._sprite, Fit(secondaryWeapon._sprite, _secondary), Color.White);
         }
 
         _minimap.Draw(spriteBatch);

--- a/src/Core/UI/Menus/InventoryMenu.cs
+++ b/src/Core/UI/Menus/InventoryMenu.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using HackenSlay;
 
 namespace HackenSlay.UI.Menus;
 
@@ -12,7 +13,15 @@ public class InventoryMenu
     private bool _togglePrev;
     private Texture2D? _pixel;
     private Rectangle _bounds;
-    private int _selectedIndex;
+    private Rectangle[] _cells = Array.Empty<Rectangle>();
+    private Rectangle[] _hotbars = Array.Empty<Rectangle>();
+    private Rectangle _primary;
+    private Rectangle _secondary;
+    private bool _dragging;
+    private int _dragIndex;
+    private Item? _dragItem;
+    private Vector2 _dragOffset;
+    private bool _mousePrev;
 
     public void LoadContent(GameHS game)
     {
@@ -25,6 +34,29 @@ public class InventoryMenu
             game.Window.ClientBounds.Height / 2 - height / 2,
             width,
             height);
+
+        int cellSize = 48;
+        int padding = 10;
+        _cells = new Rectangle[16];
+        for (int r = 0; r < 4; r++)
+        {
+            for (int c = 0; c < 4; c++)
+            {
+                int x = _bounds.X + padding + c * (cellSize + padding);
+                int y = _bounds.Y + padding + r * (cellSize + padding);
+                _cells[r * 4 + c] = new Rectangle(x, y, cellSize, cellSize);
+            }
+        }
+
+        int bottom = game.GraphicsDevice.PresentationParameters.BackBufferHeight - cellSize - padding;
+        _hotbars = new Rectangle[4];
+        for (int i = 0; i < 4; i++)
+        {
+            int x = padding + i * (cellSize + padding);
+            _hotbars[i] = new Rectangle(x, bottom, cellSize, cellSize);
+        }
+        _primary = new Rectangle(padding, bottom - cellSize - padding, cellSize, cellSize);
+        _secondary = new Rectangle(padding + cellSize + padding, bottom - cellSize - padding, cellSize, cellSize);
     }
 
     public void Update(GameHS game)
@@ -36,52 +68,109 @@ public class InventoryMenu
         }
         _togglePrev = pressed;
 
-        if (!_isVisible) return;
+        if (!_isVisible)
+            return;
 
         var items = game.player.Inventory.Items;
-        if (items.Count == 0) return;
-
-        KeyboardState ks = Keyboard.GetState();
-        if (ks.IsKeyDown(Keys.Down))
-        {
-            _selectedIndex = Math.Min(_selectedIndex + 1, items.Count - 1);
-        }
-        if (ks.IsKeyDown(Keys.Up))
-        {
-            _selectedIndex = Math.Max(_selectedIndex - 1, 0);
-        }
 
         MouseState ms = Mouse.GetState();
-        if (ms.LeftButton == ButtonState.Pressed)
+        Vector2 mouse = new Vector2(ms.X, ms.Y);
+
+        if (ms.LeftButton == ButtonState.Pressed && !_mousePrev)
         {
-            int y = _bounds.Y + 20;
-            for (int i = 0; i < items.Count; i++)
+            for (int i = 0; i < items.Count && i < _cells.Length; i++)
             {
-                Rectangle itemRect = new Rectangle(_bounds.X + 20, y - 4, _bounds.Width - 40, 20);
-                if (itemRect.Contains(ms.Position))
+                if (_cells[i].Contains(ms.Position))
                 {
-                    _selectedIndex = i;
+                    _dragging = true;
+                    _dragIndex = i;
+                    _dragItem = items[i];
+                    _dragOffset = mouse - new Vector2(_cells[i].X, _cells[i].Y);
                     break;
                 }
-                y += 20;
             }
         }
+        else if (ms.LeftButton == ButtonState.Released && _mousePrev && _dragging && _dragItem != null)
+        {
+            bool handled = false;
+            for (int i = 0; i < _cells.Length && i < items.Count; i++)
+            {
+                if (_cells[i].Contains(ms.Position))
+                {
+                    game.player.Inventory.MoveItem(_dragIndex, i);
+                    handled = true;
+                    break;
+                }
+            }
+
+            for (int i = 0; i < _hotbars.Length && !handled; i++)
+            {
+                if (_hotbars[i].Contains(ms.Position))
+                {
+                    game.player.Inventory.MoveItem(_dragIndex, i);
+                    handled = true;
+                    break;
+                }
+            }
+
+
+            if (!handled && !_bounds.Contains(ms.Position))
+            {
+                game.player.DropItem(game, _dragItem);
+                handled = true;
+            }
+
+            _dragging = false;
+            _dragItem = null;
+        }
+
+        _mousePrev = ms.LeftButton == ButtonState.Pressed;
     }
 
     public void Draw(GameHS game, SpriteBatch spriteBatch)
     {
-        if (!_isVisible || _pixel == null) return;
+        if (!_isVisible || _pixel == null)
+            return;
+
         spriteBatch.Draw(_pixel, _bounds, Color.Black * 0.8f);
 
         var items = game.player.Inventory.Items;
-        int y = _bounds.Y + 20;
-        for (int i = 0; i < items.Count; i++)
+        for (int i = 0; i < _cells.Length; i++)
         {
-            Color color = i == _selectedIndex ? Color.Yellow : Color.White;
-            spriteBatch.DrawString(game._font, items[i]._name, new Vector2(_bounds.X + 20, y), color);
-            y += 20;
+            spriteBatch.Draw(_pixel, _cells[i], Color.Black * 0.5f);
+            if (i < items.Count && (!_dragging || i != _dragIndex))
+            {
+                var tex = items[i]._sprite;
+                if (tex != null)
+                {
+                    spriteBatch.Draw(tex, Fit(tex, _cells[i]), Color.White);
+                }
+            }
+        }
+
+        for (int i = 0; i < _hotbars.Length; i++)
+        {
+            spriteBatch.Draw(_pixel, _hotbars[i], Color.Black * 0.5f);
+        }
+        spriteBatch.Draw(_pixel, _primary, Color.Black * 0.5f);
+        spriteBatch.Draw(_pixel, _secondary, Color.Black * 0.5f);
+
+        if (_dragging && _dragItem != null && _dragItem._sprite != null)
+        {
+            Vector2 pos = new Vector2(Mouse.GetState().X, Mouse.GetState().Y) - _dragOffset;
+            spriteBatch.Draw(_dragItem._sprite, new Rectangle((int)pos.X, (int)pos.Y, _cells[0].Width, _cells[0].Height), Color.White);
         }
     }
 
     public bool IsVisible => _isVisible;
+
+    private static Rectangle Fit(Texture2D tex, Rectangle bounds)
+    {
+        float scale = Math.Min((float)bounds.Width / tex.Width, (float)bounds.Height / tex.Height);
+        int w = (int)(tex.Width * scale);
+        int h = (int)(tex.Height * scale);
+        int x = bounds.X + (bounds.Width - w) / 2;
+        int y = bounds.Y + (bounds.Height - h) / 2;
+        return new Rectangle(x, y, w, h);
+    }
 }

--- a/src/Objects/Player/Inventory/Inventory.cs
+++ b/src/Objects/Player/Inventory/Inventory.cs
@@ -29,6 +29,23 @@ public class Inventory
         _items.Remove(item);
     }
 
+    /// <summary>
+    /// Moves an item from one index to another within the inventory list.
+    /// </summary>
+    public void MoveItem(int fromIndex, int toIndex)
+    {
+        if (fromIndex < 0 || fromIndex >= _items.Count)
+            return;
+        if (toIndex < 0 || toIndex >= _items.Count)
+            return;
+        if (fromIndex == toIndex)
+            return;
+
+        Item item = _items[fromIndex];
+        _items.RemoveAt(fromIndex);
+        _items.Insert(toIndex, item);
+    }
+
 
     /// <summary>
     /// Gets the list of items currently in the inventory.

--- a/src/Objects/Player/Player.cs
+++ b/src/Objects/Player/Player.cs
@@ -21,10 +21,37 @@ public class Player : AnimationObject
 {
     ItemActionHandler itemActionHandler;
     private Weapon _currentWeapon;
+    private Weapon _secondaryWeapon;
     private const int DesiredWidth = 64;
     private const int DesiredHeight = 64;
     public Inventory Inventory { get; } = new Inventory();
     public Weapon CurrentWeapon => _currentWeapon;
+    public Weapon SecondaryWeapon => _secondaryWeapon;
+
+    public void EquipPrimary(Weapon weapon)
+    {
+        if (weapon == null)
+            return;
+        _currentWeapon = weapon;
+    }
+
+    public void EquipSecondary(Weapon weapon)
+    {
+        if (weapon == null)
+            return;
+        _secondaryWeapon = weapon;
+    }
+
+    public void DropItem(GameHS game, Item item)
+    {
+        if (item == null)
+            return;
+        Inventory.Remove(item);
+        item._isActive = true;
+        item._isVisible = true;
+        item._pos = _pos;
+        game?.AddObject(item);
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Player"/> class.
@@ -37,6 +64,7 @@ public class Player : AnimationObject
         itemActionHandler = new ItemActionHandler(this, game);
 
         _currentWeapon = new Gun();
+        _secondaryWeapon = _currentWeapon;
 
         _isActive = true;
         _isVisible = true;
@@ -60,6 +88,7 @@ public class Player : AnimationObject
         Size = new Vector2(DesiredWidth, DesiredHeight);
         itemActionHandler.LoadContent(game);
         _currentWeapon.LoadContent(game);
+        _secondaryWeapon.LoadContent(game);
         audioManager.LoadSound(game.Content, "player_attack", "audio/attack");
     }
 
@@ -99,6 +128,7 @@ public class Player : AnimationObject
     {
         itemActionHandler.Update(game, gameTime);
         _currentWeapon.Update(game, gameTime);
+        _secondaryWeapon.Update(game, gameTime);
 
         if (game.userInput.IsActionPressed("primary_attack"))
         {
@@ -108,7 +138,7 @@ public class Player : AnimationObject
 
         if (game.userInput.IsActionPressed("secondary_attack"))
         {
-            itemActionHandler.SecondaryAttack(game);
+            _secondaryWeapon.Use(_pos, Vector2.Zero, this, game.userInput.GetMousePosition());
         }
 
     }

--- a/src/Tests/HackenSlay.Tests/InventoryTests.cs
+++ b/src/Tests/HackenSlay.Tests/InventoryTests.cs
@@ -1,0 +1,29 @@
+using HackenSlay.Core.Player;
+using Xunit;
+
+namespace HackenSlay.Tests;
+
+public class InventoryTests
+{
+    private class TestItem : Item
+    {
+        public TestItem() { _isActive = true; _isVisible = true; }
+        public override void Update(GameHS game, Microsoft.Xna.Framework.GameTime gameTime) { }
+        public override void Draw(GameHS game, Microsoft.Xna.Framework.Graphics.SpriteBatch spriteBatch) { }
+        public override void Handle(GameHS game) { }
+    }
+
+    [Fact]
+    public void MoveItemChangesOrder()
+    {
+        var inv = new Inventory();
+        var a = new TestItem();
+        var b = new TestItem();
+        var c = new TestItem();
+        inv.Add(a);
+        inv.Add(b);
+        inv.Add(c);
+        inv.MoveItem(0, 2);
+        Assert.Equal(a, inv.Items[2]);
+    }
+}

--- a/src/Tests/HackenSlay.Tests/PlayerInventoryTests.cs
+++ b/src/Tests/HackenSlay.Tests/PlayerInventoryTests.cs
@@ -1,0 +1,27 @@
+using HackenSlay;
+using Xunit;
+
+namespace HackenSlay.Tests;
+
+public class PlayerInventoryTests
+{
+    private class DummyWeaponItem : Weapon
+    {
+        public DummyWeaponItem() : base(1,1,1) {}
+        public override void Update(GameHS game, Microsoft.Xna.Framework.GameTime gameTime) {}
+        public override void Draw(GameHS game, Microsoft.Xna.Framework.Graphics.SpriteBatch spriteBatch) {}
+        public override void Use(Microsoft.Xna.Framework.Vector2 p, Microsoft.Xna.Framework.Vector2 d, Player pl, Microsoft.Xna.Framework.Vector2 t) {}
+    }
+
+    [Fact]
+    public void DropItemRemovesFromInventory()
+    {
+        var player = new Player(null);
+        var item = new DummyItem();
+        player.Inventory.Add(item);
+        player.DropItem(null, item);
+        Assert.DoesNotContain(item, player.Inventory.Items);
+        Assert.True(item._isActive);
+        Assert.True(item._isVisible);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Inventory.MoveItem`
- allow dropping items back on the ground
- support secondary weapon display
- create draggable inventory grid overlay
- add inventory tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687ac9040aa88329b6a3a389e788129e