### PR TITLE
Fix Minimap initialization

### DIFF
--- a/src/Core/UI/HUD/GameHud.cs
+++ b/src/Core/UI/HUD/GameHud.cs
@@ -14,9 +14,9 @@ public class GameHud
     private Rectangle _secondary;
     private Minimap _minimap;
 
-    public GameHud(GameHS game)
+    public GameHud()
     {
-        _minimap = new Minimap(game);
+        _minimap = new Minimap();
     }
 
     public void LoadContent(GameHS game, MapGenerator generator)

--- a/src/Core/UI/HUD/Minimap.cs
+++ b/src/Core/UI/HUD/Minimap.cs
@@ -10,7 +10,11 @@ public class Minimap
     private Texture2D? _mapTexture;
     private Rectangle _bounds;
 
-    public Minimap(GameHS game)
+    public Minimap()
+    {
+    }
+
+    public void LoadContent(GameHS game, MapGenerator generator)
     {
         int size = 150;
         _bounds = new Rectangle(
@@ -18,10 +22,6 @@ public class Minimap
             10,
             size,
             size);
-    }
-
-    public void LoadContent(GameHS game, MapGenerator generator)
-    {
         _mapTexture = generator.CreateMinimapTexture(game.GraphicsDevice);
     }
 

--- a/src/GameHS.cs
+++ b/src/GameHS.cs
@@ -68,7 +68,7 @@ public class GameHS : Game
         _pauseMenu = new PauseMenu();
         _inventoryMenu = new InventoryMenu();
         _camera = new Camera2D();
-        _hud = new GameHud(this);
+        _hud = new GameHud();
     }
 
     protected override void Initialize()


### PR DESCRIPTION
## Summary
- defer Minimap bounds setup until LoadContent
- adjust GameHud to create Minimap without a GameHS dependency
- update GameHS to use the parameterless GameHud constructor

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_687ac9a183fc83298b68de32b8c651bf