### PR TITLE
Fix minimap initialization

### DIFF
--- a/src/Core/UI/HUD/Minimap.cs
+++ b/src/Core/UI/HUD/Minimap.cs
@@ -12,16 +12,18 @@ public class Minimap
 
     public Minimap(GameHS game)
     {
+        _bounds = Rectangle.Empty;
+    }
+
+    public void LoadContent(GameHS game, MapGenerator generator)
+    {
         int size = 150;
         _bounds = new Rectangle(
             game.GraphicsDevice.PresentationParameters.BackBufferWidth - size - 10,
             10,
             size,
             size);
-    }
 
-    public void LoadContent(GameHS game, MapGenerator generator)
-    {
         _mapTexture = generator.CreateMinimapTexture(game.GraphicsDevice);
     }
 


### PR DESCRIPTION
## Summary
- move minimap bounds initialization to `LoadContent`
- avoid accessing the graphics device too early

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687acabe0da883298bbf930f58dc4f13