### PR TITLE
Fix empty weapon slot icons

### DIFF
--- a/src/Core/UI/HUD/GameHud.cs
+++ b/src/Core/UI/HUD/GameHud.cs
@@ -76,14 +76,14 @@ public class GameHud
 
         spriteBatch.Draw(_pixel, _primary, Color.Black * 0.5f);
         var primaryWeapon = game.player.CurrentWeapon;
-        if (primaryWeapon?._sprite != null)
+        if (primaryWeapon != null && primaryWeapon._sprite != null)
         {
             spriteBatch.Draw(primaryWeapon._sprite, Fit(primaryWeapon._sprite, _primary), Color.White);
         }
 
         spriteBatch.Draw(_pixel, _secondary, Color.Black * 0.5f);
         var secondaryWeapon = game.player.SecondaryWeapon;
-        if (secondaryWeapon?._sprite != null)
+        if (secondaryWeapon != null && secondaryWeapon._sprite != null)
         {
             spriteBatch.Draw(secondaryWeapon._sprite, Fit(secondaryWeapon._sprite, _secondary), Color.White);
         }

--- a/src/Core/UI/HUD/Minimap.cs
+++ b/src/Core/UI/HUD/Minimap.cs
@@ -16,11 +16,6 @@ public class Minimap
 
     public void LoadContent(GameHS game, MapGenerator generator)
     {
-        _bounds = Rectangle.Empty;
-    }
-
-    public void LoadContent(GameHS game, MapGenerator generator)
-    {
         int size = 150;
         _bounds = new Rectangle(
             game.GraphicsDevice.PresentationParameters.BackBufferWidth - size - 10,

--- a/src/Objects/Player/Player.cs
+++ b/src/Objects/Player/Player.cs
@@ -20,25 +20,21 @@ namespace HackenSlay;
 public class Player : AnimationObject
 {
     ItemActionHandler itemActionHandler;
-    private Weapon _currentWeapon;
-    private Weapon _secondaryWeapon;
+    private Weapon? _currentWeapon;
+    private Weapon? _secondaryWeapon;
     private const int DesiredWidth = 64;
     private const int DesiredHeight = 64;
     public Inventory Inventory { get; } = new Inventory();
-    public Weapon CurrentWeapon => _currentWeapon;
-    public Weapon SecondaryWeapon => _secondaryWeapon;
+    public Weapon? CurrentWeapon => _currentWeapon;
+    public Weapon? SecondaryWeapon => _secondaryWeapon;
 
-    public void EquipPrimary(Weapon weapon)
+    public void EquipPrimary(Weapon? weapon)
     {
-        if (weapon == null)
-            return;
         _currentWeapon = weapon;
     }
 
-    public void EquipSecondary(Weapon weapon)
+    public void EquipSecondary(Weapon? weapon)
     {
-        if (weapon == null)
-            return;
         _secondaryWeapon = weapon;
     }
 
@@ -87,8 +83,8 @@ public class Player : AnimationObject
         AnimationHandler.LoadContent(game, _animationdata, DesiredWidth, DesiredHeight);
         Size = new Vector2(DesiredWidth, DesiredHeight);
         itemActionHandler.LoadContent(game);
-        _currentWeapon.LoadContent(game);
-        _secondaryWeapon.LoadContent(game);
+        _currentWeapon?.LoadContent(game);
+        _secondaryWeapon?.LoadContent(game);
         audioManager.LoadSound(game.Content, "player_attack", "audio/attack");
     }
 
@@ -101,7 +97,7 @@ public class Player : AnimationObject
     {
 
         AnimationHandler.Draw(game, spriteBatch, this);
-        _currentWeapon.Draw(game, spriteBatch);
+        _currentWeapon?.Draw(game, spriteBatch);
     }
 
     /// <summary>
@@ -127,16 +123,16 @@ public class Player : AnimationObject
     public void UpdateAction(GameHS game, GameTime gameTime)
     {
         itemActionHandler.Update(game, gameTime);
-        _currentWeapon.Update(game, gameTime);
-        _secondaryWeapon.Update(game, gameTime);
+        _currentWeapon?.Update(game, gameTime);
+        _secondaryWeapon?.Update(game, gameTime);
 
-        if (game.userInput.IsActionPressed("primary_attack"))
+        if (game.userInput.IsActionPressed("primary_attack") && _currentWeapon != null)
         {
             _currentWeapon.Use(_pos, Vector2.Zero, this, game.userInput.GetMousePosition());
             audioManager.PlaySound("player_attack");
         }
 
-        if (game.userInput.IsActionPressed("secondary_attack"))
+        if (game.userInput.IsActionPressed("secondary_attack") && _secondaryWeapon != null)
         {
             _secondaryWeapon.Use(_pos, Vector2.Zero, this, game.userInput.GetMousePosition());
         }


### PR DESCRIPTION
## Summary
- don't render weapon icons when no weapon equipped
- make `Player` weapon fields nullable and guard usage
- remove duplicate LoadContent from `Minimap`

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_687acda1791c8329aa3bf072738c0f3b