### PR TITLE
Hide missing sprites

### DIFF
--- a/src/Core/UI/HUD/Minimap.cs
+++ b/src/Core/UI/HUD/Minimap.cs
@@ -16,11 +16,6 @@ public class Minimap
 
     public void LoadContent(GameHS game, MapGenerator generator)
     {
-        _bounds = Rectangle.Empty;
-    }
-
-    public void LoadContent(GameHS game, MapGenerator generator)
-    {
         int size = 150;
         _bounds = new Rectangle(
             game.GraphicsDevice.PresentationParameters.BackBufferWidth - size - 10,

--- a/src/Objects/World/Terrain/Obstacle.cs
+++ b/src/Objects/World/Terrain/Obstacle.cs
@@ -10,6 +10,7 @@ public class Obstacle : TextureObject
     {
         IsIntangible = false;
         IsMovable = false;
+        _isVisible = false; // obstacles are collision only, not drawn
     }
 
     public override void LoadContent(GameHS game)

--- a/src/Objects/World/Terrain/TerrainObject.cs
+++ b/src/Objects/World/Terrain/TerrainObject.cs
@@ -9,5 +9,6 @@ public class TerrainObject : TextureObject
     {
         IsMovable = false;
         IsIntangible = false;
+        _isVisible = false; // terrain objects are collision only
     }
 }

--- a/src/Objects/World/Tiles/EnemySpawnTile.cs
+++ b/src/Objects/World/Tiles/EnemySpawnTile.cs
@@ -9,5 +9,6 @@ public class EnemySpawnTile : TextureObject
     {
         IsMovable = false;
         IsIntangible = true;
+        _isVisible = false; // spawn markers are invisible
     }
 }


### PR DESCRIPTION
## Summary
- remove duplicate Minimap LoadContent method
- hide obstacle-type objects so they don't show missing textures

## Testing
- `dotnet build`
- `dotnet run`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_687acc821f688329b4cf09e2c87cb27c