### PR TITLE
Fix animation frame reset

### DIFF
--- a/src/Core/Animation/Animation.cs
+++ b/src/Core/Animation/Animation.cs
@@ -29,6 +29,15 @@ public class Animation
     private int _currentFrame;
 
     /// <summary>
+    /// Resets the animation to the first frame.
+    /// </summary>
+    internal void Reset()
+    {
+        _currentFrame = 0;
+        _elapsedTime = 0;
+    }
+
+    /// <summary>
     /// Creates a new animation using the given frame list.
     /// </summary>
     public Animation(PlayerDirection direction, PlayerState state, List<Rectangle> frames, int frameTime)

--- a/src/Core/Animation/AnimationHandler.cs
+++ b/src/Core/Animation/AnimationHandler.cs
@@ -32,6 +32,8 @@ public class AnimationHandler
     private readonly Dictionary<(PlayerState, PlayerDirection), Animation> _animations;
     public PlayerDirection _playerDirection { get; set; }
     public PlayerState _playerState { get; set; }
+    private PlayerDirection _previousDirection;
+    private PlayerState _previousState;
     public string assetName { get; private set; }
     private int _targetWidth;
     private int _targetHeight;
@@ -75,6 +77,9 @@ public class AnimationHandler
             _targetWidth = GetSubImage().Width;
             _targetHeight = GetSubImage().Height;
         }
+
+        _previousState = _playerState;
+        _previousDirection = _playerDirection;
     }
 
     /// <summary>
@@ -116,6 +121,13 @@ public class AnimationHandler
         var found = _animations.TryGetValue((_playerState, _playerDirection), out var anim);
         if (found)
         {
+            if (_previousState != _playerState || _previousDirection != _playerDirection)
+            {
+                anim.Reset();
+                _previousState = _playerState;
+                _previousDirection = _playerDirection;
+            }
+
             Debug.Log($"Direction: {anim._direction}, State: {anim._state}", DebugLevel.MEDIUM, DebugCategory.ANIMATIONHANDLER);
             anim.Update(gameTime);
         }


### PR DESCRIPTION
## Summary
- reset Animation when player changes direction or state
- add tracking of previous player direction/state

## Testing
- `dotnet test HackenSlay.sln`

------
https://chatgpt.com/codex/tasks/task_e_687acfa5030c8329bd451ef546f201fe